### PR TITLE
Feature/equity clean up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,4 +126,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.15.4
+   2.0.2

--- a/source/includes/_bulk-payments.md
+++ b/source/includes/_bulk-payments.md
@@ -11,7 +11,7 @@ transfer money to multiple investors.
 Said endpoint references a `totalPayout` amount, and takes a list of all the investors and the amount each is due to be paid.
 
 The call to [`POST /transfers/batch`](/#payments-manager-post-transfers-batch) will return a 201 Created response
-with a `status` field in the body of 'AWAITING FUNDS'.
+with a `status` field in the body of `AWAITING_FUNDS`.
 
 ⚠️ Please note that this response only indicates that the batch payment instruction has been received. 
 The distribution of the batch to investors will not occur until the necessary funds are received. 
@@ -26,28 +26,35 @@ The status of the money transfer is further broken down at a per investor level.
 
 ## Batch Model
 
-| Key                         | JSON Type | Value Type | Value Description                                                 |
-|-----------------------------|-----------|------------|-------------------------------------------------------------------|
-| batchId                     | String    | UUID       | The platform generated UUID of the batch payment posting.         |
-| type                        | String    | Enum       | The type of batch payment. Values: MIGRATION, BONUS, CARD_PAYMENTS|
-| status                      | String    | Enum       | Response Only. Values: AWAITING_FUNDS, DISTRIBUTING, COMPLETE.    |
-| totalPayout.currency        | String    | ISO 4217   | The currency that the total dividend payment is in.               |
-| totalPayout.amount          | Number    | Number     | The total amount to be paid out.                                  |
-| payments[].clientId         | String    | Client ID  | The client ID for the batch payment.                              |
-| payments[].accountType      | String    | Enum       | The client's account to pay to. Values: GOJI_INVESTMENT, ISA.     |
-| payments[].amount.currency  | String    | ISO 4217   | The currency that the batch payment is paid in.                   |
-| payments[].amount.amount    | Number    | Number     | The total amount to be paid to this investor.                     |
-| payments[].status           | String    | Enum       | Response Only. Values: PENDING, PAID.                             |
-| payments[].sourceOfFunds    | Object    | Object     | Optional. The client's active bank account details.               |
-| sourceOfFunds.accountName   | String    | String     | The client's bank account name.                                   |
-| sourceOfFunds.accountNumber | String    | String     | The client's bank account number.                                 |
-| sourceOfFunds.sortCode      | String    | String     | The client's bank account sort code.                              |
-| payTo.accountName           | String    | String     | Response Only. The account number to send payment to.             |
-| payTo.accountNumber         | String    | String     | Response Only. The account number to send payment to.             |
-| payTo.sortCode              | String    | String     | Response Only. The sort code to send payment to.                  |
-| payTo.reference             | String    | String     | Response Only. The reference to use when sending payment.         |
+### Required Attributes
+
+| Key                          | JSON Type | Value Type | Value Description                                                            |
+|------------------------------|-----------|------------|------------------------------------------------------------------------------|
+| batchId                      | String    | BatchId    | The platform generated UUID of the batch payment posting.                    |
+| type                         | String    | Enum       | The type of batch payment. Values: `MIGRATION`, `BONUS`, `CARD_PAYMENTS`     |
+| status                       | String    | Enum       | Response Only. Values: `AWAITING_FUNDS`, `DISTRIBUTING`, `COMPLETE`.         |
+| totalPayout.amount           | Number    | Number     | The total amount to be paid out to investors.                                |
+| totalPayout.currency         | String    | ISO 4217   | The currency that the `totalPayout.currency` is in.                          |
+| payments[]                   | Array     | Object     | The list of payments to be made as part of this batch instruction.           |
+| payments[].clientId          | String    | Object     | The clientId of the investor associated with this individual payment.        |
+| payments[] .accountType      | String    | Enum       | The client's account to pay to. Values: `GOJI_INVESTMENT`, `ISA`.            |
+| payments[] .amount.currency  | String    | ISO 4217   | The currency associated with a `payments[].amount.amount`.                   |
+| payments[] .amount.amount    | Number    | Number     | The total amount to be paid to this investor.                                |
 
 
+### Optional Attributes
+
+| Key                          | JSON Type | Value Type | Value Description                                                            |
+|------------------------------|-----------|------------|------------------------------------------------------------------------------|
+| payments[].sourceOfFunds     | Object    | Object     | Optional but inclusion preferred. The client's active bank account details.  |
+| sourceOfFunds.accountName    | String    | String     | The investor's bank account name.                                            |
+| sourceOfFunds.accountNumber  | String    | String     | The client's bank account number.                                            |
+| sourceOfFunds.sortCode       | String    | String     | The client's bank account sort code.                                         |
+| payments[].status            | String    | Enum       | Response Only. Values: `PENDING`, `DISTRIBUTED`.                             |
+| payTo.accountName            | String    | String     | Response Only. The name of the account to send payment to.                   |
+| payTo.accountNumber          | String    | String     | Response Only. The account number to send payment to.                        |
+| payTo.sortCode               | String    | String     | Response Only. The sort code to send payment to.                             |
+| payTo.reference              | String    | String     | Response Only. The reference to use when sending payment.                    |
 
 
 ## `POST /transfers/batch`
@@ -148,11 +155,11 @@ Creates a new batch payment instruction to transfer money to a list of investors
 
 ### Request
 
-Body: [Batch Model](/#payments-manager-batch-payments-model)
+Body: [Batch Model](/#payments-manager-batch-model)
 
 ### Response
 
-Body: [Batch Model](/#payments-manager-batch-payments-model)
+Body: [Batch Model](/#payments-manager-batch-model)
 
 
 Http Status: 
@@ -243,13 +250,13 @@ Body: None
 
 ### Response
 
-Body: [Batch Payment Model](/#payments-manager-batch-payments-model) 
+Body: [Batch Payment Model](/#payments-manager-batch-model) 
 
 Http Status: 
 
 | Code             | Description                                      | Body       | Content-Type     |
 |------------------|--------------------------------------------------|------------|------------------|
-| 200 Created      | batch payment exists and is return in the body   | Batch      | application/json |
+| 200 OK           | batch payment exists and is return in the body   | Batch      | application/json |
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 | 404 Not Found    | No batch payment with this UUID exists           | None       | n/a              |

--- a/source/includes/_corporate-actions.md
+++ b/source/includes/_corporate-actions.md
@@ -20,7 +20,7 @@ The distribution of the dividend to investors will not occur until the necessary
 
 Funds should be sent to the bank details specified in the `PayTo` section of the response, including the `payTo.reference`.
 
-Once payment has been made, the [`GET /corporate-actions/dividends/{dividendId}`](/#settlement-equity-get-corporate-actions-dividends-dividendid) 
+Once payment has been made, the [`GET /corporate-actions/dividends/{id}`](/#settlement-equity-get-corporate-actions-dividends-id) 
 endpoint can be used to see the current status of the dividend instruction.
 
 The status of the money transfer is further broken down at a per investor level. 
@@ -38,7 +38,7 @@ The status of the money transfer is further broken down at a per investor level.
 | totalPayout. currency        | String    | ISO 4217        | The currency that the total dividend payment is in.                               |
 | totalPayout. amount          | Number    | Number          | The overall amount to be paid out.                                                |
 | payments[]                   | Array     | List            | The list of all individual payments due to be paid out.                           |
-| payments[]. clientId         | String    | Object          | The investor's clientId for a dividend payment.                                   |
+| payments[]. clientId         | String    | String          | The investor's clientId for a dividend payment.                                   |
 | payments[]. accountType      | String    | Enum            | The account type to pay the dividend to for some `clientId`. Values: `GIA`, `ISA`.|
 | payments[]. payment.amount   | Number    | Number          | The total amount to be paid to a `clientId` in the given `payment.currency`.      |
 | payments[]. payment.currency | String    | ISO 4217        | The currency corresponding to the `payment.amount` to be paid.                    |
@@ -165,7 +165,7 @@ Http Status:
 
 
 
-## `GET /corporate-actions/dividends/{dividendId}`
+## `GET /corporate-actions/dividends/{id}`
 
 To see the current state of a dividend instruction, this endpoint can be used.  
 
@@ -229,7 +229,7 @@ X-GOJI-REQUEST-ID: 6937bd3b-e3de-4fd6-9bd9-c87cd7305180
 
 ### Description
 
-Retrieves the details of an existing dividend.
+Retrieves the details of an existing dividend given a dividend `id` is supplied.
 
 ### Request
 

--- a/source/includes/_corporate-actions.md
+++ b/source/includes/_corporate-actions.md
@@ -10,15 +10,15 @@ The API is currently under construction.
 The [`POST /corporate-actions/dividends`](/#settlement-equity-post-corporate-actions-dividends) endpoint can be used to pay dividends 
 to investors that hold shares in an instrument.
  
-Said endpoint references an instrument, and takes a list of all the investors that are shareholders to be paid. 
+Said endpoint references a registered instrument, and takes a list of all the investors that are shareholders to be paid. 
 
 The call to [`POST /corporate-actions/dividends`](/#settlement-equity-post-corporate-actions-dividends) will return a 201 Created response
-with a `status` field in the body of 'AWAITING FUNDS'.
+with a `status` field in the Dividend body of `AWAITING FUNDS`.
 
 ⚠️ Please note that this response only indicates that the dividend instruction has been received. 
-The distribution of the dividend to investors will not occur until the necessary funds are received. 
+The distribution of the dividend to investors will not occur until the necessary funds have been sent. 
 
-The response will include a payTo section. Payment should be sent to the bank details specified, including the `payTo.reference`.
+Funds should be sent to the bank details specified in the `PayTo` section of the response, including the `payTo.reference`.
 
 Once payment has been made, the [`GET /corporate-actions/dividends/{dividendId}`](/#settlement-equity-get-corporate-actions-dividends-dividendid) 
 endpoint can be used to see the current status of the dividend instruction.
@@ -28,23 +28,34 @@ The status of the money transfer is further broken down at a per investor level.
 
 ## Dividends Model
 
-| Key                         | JSON Type | Value Type | Value Description                                               |
-|-----------------------------|-----------|------------|-----------------------------------------------------------------|
-| id                          | String    | UUID       | The platform generated UUID of the dividend posting.            |
-| instrumentSymbol            | String    | UUID       | The platform generated unique ID/symbol of the instrument.      |
-| status                      | String    | Enum       | Response Only. Values: AWAITING_FUNDS, DISTRIBUTING, COMPLETE.  |
-| totalPayout.currency        | String    | ISO 4217   | The currency that the total dividend payment is in.             |
-| totalPayout.amount          | Number    | Number     | The total amount to be paid out.                                |
-| payments[].clientId         | String    | Client ID  | The client ID for the dividend payment.                         |
-| payments[].accountType      | String    | Enum       | The account to pay the dividend to. Values: GIA, ISA.           |
-| payments[].payment.currency | String    | ISO 4217   | The currency that the dividend is paid in.                      |
-| payments[].payment.amount   | Number    | Number     | The total amount to be paid to this investor.                   |
-| payments[].status           | String    | Enum       | Response Only. Values: PENDING, PAID.                           |
-| payTo.accountNumber         | String    | String     | Response Only. The account number to send payment to.           |
-| payTo.sortCode              | String    | String     | Response Only. The sort code to send payment to.                |
-| payTo.reference             | String    | String     | Response Only. The reference to use when sending payment.       |
+
+### Required Attributes
+
+| Key                          | JSON Type | Value Type      | Value Description                                                                 |
+|------------------------------|-----------|-----------------|-----------------------------------------------------------------------------------|
+| id                           | String    | DividendId      | The platform generated UUID of the dividend posting.                              |
+| instrumentSymbol             | String    | InstrumentSymbol| The unique ID/symbol of the instrument registered by the platform.                |
+| totalPayout. currency        | String    | ISO 4217        | The currency that the total dividend payment is in.                               |
+| totalPayout. amount          | Number    | Number          | The overall amount to be paid out.                                                |
+| payments[]                   | Array     | List            | The list of all individual payments due to be paid out.                           |
+| payments[]. clientId         | String    | Object          | The investor's clientId for a dividend payment.                                   |
+| payments[]. accountType      | String    | Enum            | The account type to pay the dividend to for some `clientId`. Values: `GIA`, `ISA`.|
+| payments[]. payment.amount   | Number    | Number          | The total amount to be paid to a `clientId` in the given `payment.currency`.      |
+| payments[]. payment.currency | String    | ISO 4217        | The currency corresponding to the `payment.amount` to be paid.                    |
 
 
+### Additional Response Attributes
+
+The following list of attributes are response-only and are expected to always be present on a response.
+
+| Key                         | JSON Type | Value Type      | Value Description                                                                                                     |
+|-----------------------------|-----------|-----------------|-----------------------------------------------------------------------------------------------------------------------|
+| status                      | String    | Enum            | Response Only. The status of the overall dividend instruction. Values: `AWAITING_FUNDS`, `DISTRIBUTING`, `COMPLETE`.  |
+| payments[].status           | String    | Enum            | Response Only. The status of an individual payment under `payments`. Values: `PENDING`, `COMPLETE`.                   |
+| payTo.accountName           | String    | String          | Response Only. The account name associated with the `accountNumber` and `sortCode` below.                             |
+| payTo.accountNumber         | String    | String          | Response Only. The account number to send payment to.                                                                 |
+| payTo.sortCode              | String    | String          | Response Only. The sort code to send payment to.                                                                      | 
+| payTo.reference             | String    | String          | Response Only. The reference to use when sending payment.                                                             |
 
 
 ## `POST /corporate-actions/dividends`
@@ -57,14 +68,14 @@ X-GOJI-REQUEST-ID: 49801f79-5347-4db5-a2b9-59e6cf3e0a22
 
 {
   "id": "627e27b2-75be-4673-ba5a-7f765a8ace89",
-  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
+  "instrumentSymbol": "instrument1",
   "totalPayout": {
     "currency": "GBP",
     "amount": 180
   },
   "payments": [
     {
-      "clientId": "PROP-12345",
+      "clientId": "clientId",
       "accountType": "GIA",
       "payment": {
         "currency": "GBP",
@@ -72,7 +83,7 @@ X-GOJI-REQUEST-ID: 49801f79-5347-4db5-a2b9-59e6cf3e0a22
       }
     },
     {
-      "clientId": "PROP-23456",
+      "clientId": "clientId2",
       "accountType": "GIA",
       "payment": {
         "currency": "GBP",
@@ -90,19 +101,15 @@ X-GOJI-REQUEST-ID: 49801f79-5347-4db5-a2b9-59e6cf3e0a22
 
 {
   "id": "627e27b2-75be-4673-ba5a-7f765a8ace89",
-  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
+  "instrumentSymbol": "instrument1",
   "status": "AWAITING_FUNDS",
-  "dividendPerShare": {
-    "currency": "GBP",
-    "amount": 0.12
-  },
   "totalPayout": {
     "currency": "GBP",
     "amount": 180
   },
   "payments": [
     {
-      "clientId": "PROP-12345",
+      "clientId": "clientId",
       "accountType": "GIA",
       "payment": {
         "currency": "GBP",
@@ -111,7 +118,7 @@ X-GOJI-REQUEST-ID: 49801f79-5347-4db5-a2b9-59e6cf3e0a22
       "status": "PENDING"
     },
     {
-      "clientId": "PROP-23456",
+      "clientId": "clientId2",
       "accountType": "GIA",
       "payment": {
         "currency": "GBP",
@@ -120,10 +127,11 @@ X-GOJI-REQUEST-ID: 49801f79-5347-4db5-a2b9-59e6cf3e0a22
       "status": "PENDING"
     }
   ],
-  "pay": {
-    "accountNumber": "12345678",
-    "sortCode": "040004",
-    "reference": "abc123def456"
+  "payTo": {
+    "accountName": "Platform1 - Receiving",
+    "accountNumber": "123456789",
+    "sortCode": "123456",
+    "reference": "OR0CE628FF"
   }
 }
 ```
@@ -184,28 +192,24 @@ X-GOJI-REQUEST-ID: 6937bd3b-e3de-4fd6-9bd9-c87cd7305180
 
 {
   "id": "627e27b2-75be-4673-ba5a-7f765a8ace89",
-  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
-  "status": "DISTRIBUTING",
-  "dividendPerShare": {
-    "currency": "GBP",
-    "amount": 0.12
-  },
+  "instrumentSymbol": "instrument1",
+  "status": "AWAITING_FUNDS",
   "totalPayout": {
     "currency": "GBP",
     "amount": 180
   },
   "payments": [
     {
-      "clientId": "PROP-12345",
+      "clientId": "clientId",
       "accountType": "GIA",
       "payment": {
         "currency": "GBP",
         "amount": 120
       },
-      "status": "PAID"
+      "status": "PENDING"
     },
     {
-      "clientId": "PROP-23456",
+      "clientId": "clientId2",
       "accountType": "GIA",
       "payment": {
         "currency": "GBP",
@@ -214,10 +218,11 @@ X-GOJI-REQUEST-ID: 6937bd3b-e3de-4fd6-9bd9-c87cd7305180
       "status": "PENDING"
     }
   ],
-  "pay": {
-    "accountNumber": "12345678",
-    "sortCode": "040004",
-    "reference": "abc123def456"
+  "payTo": {
+    "accountName": "Platform1 - Receiving",
+    "accountNumber": "123456789",
+    "sortCode": "123456",
+    "reference": "OR0CE628FF"
   }
 }
 ```
@@ -238,7 +243,7 @@ Http Status:
 
 | Code             | Description                                      | Body       | Content-Type     |
 |------------------|--------------------------------------------------|------------|------------------|
-| 200 Created      | Dividend exists and is return in the body        | Dividend   | application/json |
+| 200 OK           | Dividend exists and is return in the body        | Dividend   | application/json |
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 | 404 Not Found    | No dividend with this UUID exists                | None       | n/a              |

--- a/source/includes/_instruments.md
+++ b/source/includes/_instruments.md
@@ -1,7 +1,10 @@
 ## <em>Instruments 🚧</em>
 
-The Instruments API allows an Investment Manager to [create new Instruments](/#settlement-equity-instrument-creation), and 
-[issue/allocate shares](/#settlement-equity-issuing-allocating-shares) of that instrument.
+The Instruments API allows an Investment Manager to:
+ 
+ (1) [create new instruments](/#settlement-equity-instrument-creation) and...
+ 
+ (2) [issue/ allocate shares](/#settlement-equity-issuing-allocating-shares) of that instrument
 
 This instrument can then be used for:
 
@@ -10,33 +13,48 @@ This instrument can then be used for:
 
 ## Instrument Creation
 
-Instrument creation allows registering a new [Instrument](/#settlement-equity-instrument-model), which is later referenced
-by the `InstrumentSymbol`.  Currently only equity instruments are supported.
+Instrument creation allows registering a new [Instrument](/#settlement-equity-instrument-model).
+
+This instrument would then be referenced in other documented requests by the `InstrumentSymbol` specified.  
+
+Currently only equity instruments are supported.
 
 ## Instrument Model
-```json
-{
-  "id": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
-  "assetClass": "EQUITY",
-  "primaryMarketBankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41",
-  "feeTypes": [
-    {
-      "symbol": "COMMISSION",
-      "bankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41"
-    }
-  ]
-}
-```
 
-The Instrument model used for both the [`POST /instruments`](/#settlement-equity-post-instruments) and [`GET /instruments/{InstrumentSymbol}`](/#settlement-equity-get-instruments-instrumentsymbol) endpoints.
+The Instrument model used for endpoints: 
 
-| Key                        | JSON Type | Value Type       | Value Description                                                                                |
-|----------------------------|-----------|------------------|--------------------------------------------------------------------------------------------------|
-| symbol                     | String    | InstrumentSymbol | Unique symbol used to identify this instrument.                                                  |
-| assetClass                 | String    | AssetClass       | Values: EQUITY                                                                                   |
-| primaryMarketBankAccountId | String    | BankAccountId    | The bank account ID to send primary market sale funds to.                                        |
-| feeTypes[].symbol          | String    | FeeSymbol        | A symbolic representation of the type of fee, i.e. STAMP_DUTY.                                   |
-| feeTypes[].bankAccountId   | String    | BankAccountId    | BankAccountID from [`POST /platformApi/bankAccountDetails`](/#payments-manager-post-bankaccountdetails). |
+(1) [`POST /instruments`](/#settlement-equity-post-instruments) 
+
+(2) [`GET /instruments/{InstrumentSymbol}`](/#settlement-equity-get-instruments-instrumentsymbol)
+
+⚠️ Please note that before registering instruments, BankAccountIds have to be registered at the endpoint: 
+
+[`POST /platformApi/bankAccountDetails`](/#payments-manager-post-platformapi-bankaccountdetails)
+
+before they can be used for the following instrument model attributes: 
+
+(1) `paymentInstructions.primaryMarketBankAccountId` 
+
+(2) `feeTypes[].bankAccountId`
+
+
+### Required Attributes
+
+| Key                                             | JSON Type | Value Type       | Value Description                                                                                                    |
+|-------------------------------------------------|-----------|------------------|----------------------------------------------------------------------------------------------------------------------|
+| symbol                                          | String    | InstrumentSymbol | Unique symbol used to identify this instrument. Max 100 characters.                                                  |
+| assetClass                                      | String    | AssetClass       | Values: EQUITY                                                                                                       |
+| paymentInstructions                             | Object    | Object           | Contains the attributes listed below.                                                                                |
+| paymentInstructions. primaryMarketBankAccountId | String    | BankAccountId    | The BankAccountId to send primary market sale funds to.                                                              |
+
+
+### Optional Attributes
+
+| Key                                            | JSON Type | Value Type       | Value Description                                                                                                    |
+|------------------------------------------------|-----------|------------------|----------------------------------------------------------------------------------------------------------------------|
+| paymentInstructions. feeTypes[]                | Array     | List             | A list of all additional fees associated with this instrument. Can be empty.                                         |
+| feeTypes[].symbol                              | String    | FeeSymbol        | A symbolic representation of the type of fee, i.e. STAMP_DUTY. Required if a feeType is specified.                   |
+| feeTypes[].bankAccountId                       | String    | BankAccountId    | The BankAccountId associated with the FeeSymbol.  Required if a feeType is specified.                                |
 
 ## `POST /instruments`
 
@@ -48,15 +66,18 @@ Authorization: Basic ...
 X-GOJI-CLIENT-ID: 79f33f3c-86e0-4613-ba49-9fac3c6f0eab
 
 {
-  "id": "SPV99",
+  "symbol": "SPV1",
+  "name": "Happy Parade - SPV1",
   "assetClass": "EQUITY",
-  "primaryMarketBankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41",
-  "feeTypes": [
-    {
-      "symbol": "COMMISSION",
-      "bankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41"
-    }
-  ]
+  "paymentInstructions": {
+    "primaryMarketBankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41",
+    "feeTypes": [
+      {
+        "symbol": "COMMISSION",
+        "bankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41"
+      }
+    ]
+  }
 }
 ```
 
@@ -66,15 +87,18 @@ Content-Type: application/json
 X-GOJI-REQUEST-ID: 79f33f3c-86e0-4613-ba49-9fac3c6f0eab
 
 {
-  "id": "SPV99",
+  "symbol": "SPV1",
+  "name": "Happy Parade - SPV1",
   "assetClass": "EQUITY",
-  "primaryMarketBankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41",
-  "feeTypes": [
-    {
-      "symbol": "COMMISSION",
-      "bankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41"
-    }
-  ]
+  "paymentInstructions": {
+    "primaryMarketBankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41",
+    "feeTypes": [
+      {
+        "symbol": "COMMISSION",
+        "bankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41"
+      }
+    ]
+  }
 }
 ```
 
@@ -126,19 +150,22 @@ Content-Type: application/json
 X-GOJI-REQUEST-ID: 79f33f3c-86e0-4613-ba49-9fac3c6f0eab
 
 {
-  "id": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
+  "symbol": "SPV99",
+  "name": "Happy Parade - SPV99",
   "assetClass": "EQUITY",
-  "primaryMarketBankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41",
-  "feeTypes": [
-    {
-      "symbol": "COMMISSION",
-      "bankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41"
-    }
-  ]
+  "paymentInstructions": {
+    "primaryMarketBankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41",
+    "feeTypes": [
+      {
+        "symbol": "COMMISSION",
+        "bankAccountId": "01700ae3-1b61-41c8-87d9-c59e82f33a41"
+      }
+    ]
+  }
 }
 ```
 
-Retrieves the details held about an instrument.
+Retrieves the details held on an instrument.
 
 ### Request
 
@@ -152,10 +179,12 @@ Http Status:
 
 | Code             | Description                                      | Body       | Content-Type     |
 |------------------|--------------------------------------------------|------------|------------------|
-| 200 Created      | Instrument exists and is return in the body      | Instrument | application/json |
+| 200 OK           | Instrument exists and is returned in the body    | Instrument | application/json |
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 | 404 Not Found    | No instrument with this symbol is registered     | None       | n/a              |
+
+
 
 ## Issuing / Allocating Shares
 

--- a/source/includes/_instruments.md
+++ b/source/includes/_instruments.md
@@ -2,11 +2,9 @@
 
 The Instruments API allows an Investment Manager to:
  
- (1) [create new instruments](/#settlement-equity-instrument-creation) and...
- 
- (2) [issue/ allocate shares](/#settlement-equity-issuing-allocating-shares) of that instrument
+ (1) [create new instruments](/#settlement-equity-instrument-creation) and (2) [issue/ allocate shares](/#settlement-equity-issuing-allocating-shares) of that instrument.
 
-This instrument can then be used for:
+A registered instrument can then be used for:
 
  * [Trade Settlement](/#settlement-equity-trade-settlement)
  * [Corporate Actions](/#settlement-equity-corporate-actions)
@@ -15,7 +13,7 @@ This instrument can then be used for:
 
 Instrument creation allows registering a new [Instrument](/#settlement-equity-instrument-model).
 
-This instrument would then be referenced in other documented requests by the `InstrumentSymbol` specified.  
+This instrument would then be referenced in requests to endpoints e.g. [Trade Settlement](/#settlement-equity-trade-settlement) by instrument `symbol`.  
 
 Currently only equity instruments are supported.
 
@@ -25,13 +23,13 @@ The Instrument model used for endpoints:
 
 (1) [`POST /instruments`](/#settlement-equity-post-instruments) 
 
-(2) [`GET /instruments/{InstrumentSymbol}`](/#settlement-equity-get-instruments-instrumentsymbol)
+(2) [`GET /instruments/{symbol}`](/#settlement-equity-get-instruments-symbol)
 
 ⚠️ Please note that before registering instruments, BankAccountIds have to be registered at the endpoint: 
 
 [`POST /platformApi/bankAccountDetails`](/#payments-manager-post-platformapi-bankaccountdetails)
 
-before they can be used for the following instrument model attributes: 
+before they can be used for the following instrument attributes: 
 
 (1) `paymentInstructions.primaryMarketBankAccountId` 
 
@@ -107,7 +105,7 @@ X-GOJI-REQUEST-ID: 79f33f3c-86e0-4613-ba49-9fac3c6f0eab
 Registers a new instrument which can then be referenced by its symbol in other APIs which require an `InstrumentSymbol`.
 
 
-The instrument can then be referenced by the `InstrumentSymbol` in the following APIs:
+A registered instrument can be referenced by the `InstrumentSymbol` in the following APIs:
 
  * [Trade Settlement API](/#settlement-equity-trade-settlement)
  * [Corporate Actions API](/#settlement-equity-corporate-actions)
@@ -132,7 +130,7 @@ Http Status:
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 
-## `GET /instruments/{InstrumentSymbol}`
+## `GET /instruments/{symbol}`
 
 ### Description
 
@@ -165,7 +163,7 @@ X-GOJI-REQUEST-ID: 79f33f3c-86e0-4613-ba49-9fac3c6f0eab
 }
 ```
 
-Retrieves the details held on an instrument.
+Retrieves the details held on an instrument given its `symbol` is supplied.
 
 ### Request
 
@@ -270,7 +268,7 @@ Http Status:
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 
-## `GET /allocations/{AllocationId}`
+## `GET /allocations/{id}`
 
 ```http
 GET /allocations/5dd40510-810e-4a55-a395-04819fd915b9 HTTP/1.1
@@ -299,7 +297,7 @@ Content-Type: application/json
 
 ### Description
 
-Retrieves the details of an existing allocation.
+Retrieves the details of an existing allocation given an allocation `id` is supplied.
 
 ### Request
 

--- a/source/includes/_instruments.md
+++ b/source/includes/_instruments.md
@@ -197,16 +197,16 @@ each investor's shares.
 
 ## Allocation Model
 
-| Key                  | JSON Type | Value Type       | Value Description                                              |
-|----------------------|-----------|------------------|----------------------------------------------------------------|
-| id                   | String    | UUID             | A UUID for this allocation.                                    |
-| quantity             | Number    | Number           | The (whole) number of shares to allocate.                      |
-| instrumentId         | String    | InstrumentSymbol | Property Partner generated unique ID of the instrument.        |
-| investor             | Object    | Object           | Null for non-investor allocation, or the fields below.         |
-| investor.clientId    | String    | ClientId         | Either the client ID for the investor.                         |
-| investor.accountType | String    | Enum             | Values: GIA, ISA.                                              |
-| nominee              | Object    | Object           | Null when not allocating to a nominee, else fields below.      |
-| nominee.accountType  | String    | Enum             | The nominee involved in the alloc. Values: GOJI, ORIGINATOR.   |
+| Key                  | JSON Type | Value Type       | Value Description                                               |
+|----------------------|-----------|------------------|-----------------------------------------------------------------|
+| id                   | String    | UUID             | A UUID for this allocation.                                     |
+| quantity             | Number    | Number           | The (whole) number of shares to allocate.                       |
+| instrumentSymbol     | String    | InstrumentSymbol | Platform generated unique ID of the instrument.                 |
+| investor             | Object    | Object           | Null for non-investor allocation, or the fields below.          |
+| investor.clientId    | String    | ClientId         | Either the client ID for the investor.                          |
+| investor.accountType | String    | Enum             | Values: `GIA`, `ISA`.                                           |
+| nominee              | Object    | Object           | Null when not allocating to a nominee, else fields below.       |
+| nominee.accountType  | String    | Enum             | The nominee involved in the alloc. Values: `GOJI`, `ORIGINATOR`.|
 
 ## `POST /allocations`
 
@@ -226,7 +226,7 @@ X-GOJI-CLIENT-ID: 59425d3d-cf73-44ff-aecb-590cd198a4bc
     }
   },
   "quantity": 1000000,
-  "instrumentId": "446ca5fc-4d38-4706-a50b-5b3a64d3f703"
+  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703"
 }
 ```
 
@@ -243,7 +243,7 @@ Content-Type: application/json
     }
   },
   "quantity": 1000000,
-  "instrumentId": "446ca5fc-4d38-4706-a50b-5b3a64d3f703"
+  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703"
 }
 ```
 
@@ -293,7 +293,7 @@ Content-Type: application/json
     }
   },
   "quantity": 1000000,
-  "instrumentId": "446ca5fc-4d38-4706-a50b-5b3a64d3f703"
+  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703"
 }
 ```
 
@@ -313,7 +313,7 @@ Http Status:
 
 | Code             | Description                                      | Body       | Content-Type     |
 |------------------|--------------------------------------------------|------------|------------------|
-| 200 Created      | Allocation exists and is return in the body      | Allocation | application/json |
+| 200 OK           | Allocation exists and is return in the body      | Allocation | application/json |
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 | 404 Not Found    | No allocation with this UUID exists              | None       | n/a              |

--- a/source/includes/_trade-settlement.md
+++ b/source/includes/_trade-settlement.md
@@ -13,36 +13,46 @@ To retrieve an existing trade, the [`GET /trades/{tradeId}`](#settlement-equity-
 
 ## Trade Model
 
-| Key                       | JSON Type | Value Type | Value Description                                                          |
-|---------------------------|-----------|------------|----------------------------------------------------------------------------|
-| id                        | String    | UUID       | The platform generated unique ID of the trade. Up to 100 characters.       |
-| quantity                  | Number    | Number     | The number of shares being bought/sold.                                    |
-| instrumentSymbol          | String    | ID/Symbol  | The platform generated unique ID/symbol of the instrument.                 |
-| sourceDateTime            | String    | ISO-8601   | The timestamp at which the trade was originally executed on the platform.  |
-| settlementStatus          | String    | Enum       | Response only.                                                             |
-| price                     | Object    | Object     | The price the instrument is being traded at.                               |
-| price.currency            | String    | ISO 4217   | The currency that `price.amount` is expressed in.                          |
-| price.amount              | Number    | Number     | The cost per share in `price.currency`.                                    |
-| buy                       | Object    | Object     | Represents the buy-side details of a trade                                 |
-| buy.investor              | Object    | Object     | Null for non-investor, or details investor details.                        |
-| buy.investor.clientId     | String    | Client ID  | The client ID of the investor, i.e. PROP-12345.                            |
-| buy.investor.accountType  | String    | Enum       | Values: GIA, ISA.                                                          |
-| buy.nominee               | Object    | Object     | Null when the buyer is not a nominee, else field below.                    |
-| buy.nominee.accountType   | String    | Enum       | The nominee involved in the buy. Values: GOJI, ORIGINATOR.                 |
-| buy.fees[]                | FeeSymbol | FeeSymbol  | Fields below detail a FeeSymbol registered at `POST /instrument`.          |
-| buy.fees[].symbol         | String    | String     | Optional. Fee type symbol registered at `POST /instrument`.                |
-| buy.fees[].cost.currency  | Number    | Number     | The currency of the fee.                                                   |
-| buy.fees[].cost.amount    | Number    | Number     | The amount of the fee in `cost.currency`. (not per share)                  |
-| sell                      | Object    | Object     | Represents the sell-side details of a trade                                |
-| sell.investor             | Object    | Object     | Null for non-investor, or details investor details.                        |
-| sell.investor.clientId    | String    | Client ID  | The client ID of the investor, i.e. PROP-12345.                            |
-| sell.investor.accountType | String    | Enum       | Values: GIA, ISA.                                                          |
-| sell.nominee              | Object    | Object     | Null when the seller is not a nominee, else fields below.                  |
-| sell.nominee.accountType  | String    | Enum       | The nominee involved in the sell. Values: GOJI, ORIGINATOR.                |
-| sell.fees[]               | String    | String     | Fields below detail a FeeSymbol registered at `POST /instrument`.          |
-| sell.fees[].symbol        | FeeSymbol | FeeSymbol  | Optional. Fee type symbol registered at `POST /instrument`.                |
-| sell.fees[].cost.currency | Number    | Number     | The currency of the fee.                                                   |
-| sell.fees[].cost.amount   | Number    | Number     | The amount of the fee in `cost.currency`.                                  |
+### Required Attributes 
+
+| Key                       | JSON Type | Value Type | Value Description                                                                                           |
+|---------------------------|-----------|------------|-------------------------------------------------------------------------------------------------------------|
+| id                        | String    | TradeId    | The platform generated unique ID of the trade. Up to 100 characters.                                        |
+| instrumentSymbol          | String    | ID/Symbol  | The platform generated unique ID/symbol of the instrument.                                                  |
+| quantity                  | Number    | Number     | The number of shares being bought/sold.                                                                     |
+| price                     | Object    | Object     | The price the instrument is being traded at.                                                                |
+| price.amount              | Number    | Number     | The cost per share unit in `price.currency`.                                                                |
+| price.currency            | String    | ISO 4217   | The currency that `price.amount` is expressed in.                                                           |
+| sourceDateTime            | String    | ISO 8601   | The timestamp at which the trade was originally executed on the platform.                                   |
+| buy                       | Object    | Object     | Represents the buy-side details of a trade                                                                  |
+| buy.investor              | Object    | Object     | Set to null for non-investor, or details investor details.                                                  |
+| buy.investor. clientId    | String    | Object     | The registered clientId of the investor, i.e. PROP-12345.                                                   |
+| buy.investor. accountType | String    | Enum       | Values: `GIA`, `ISA`.                                                                                       |
+| buy.nominee               | Object    | Object     | Set to null when the buyer is not a nominee, else field below.                                              |
+| buy.nominee. accountType  | String    | Enum       | The nominee involved in the buy. Values: GOJI, ORIGINATOR.                                                  |
+| buy.fees[]                | Array     | List       | Required when fees exist on the instrument being traded that the buyer needs to pay. Otherwise leave empty. |
+| sell                      | Object    | Object     | Represents the sell-side details of a trade                                                                 |
+| sell.investor             | Object    | Object     | Set to null for non-investor, or details investor details.                                                  |
+| sell.investor. clientId   | String    | Client ID  | The registered clientId of the investor, i.e. PROP-12345.                                                   |
+| sell.investor. accountType| String    | Enum       | Values: `GIA`, `ISA`.                                                                                       |
+| sell.nominee              | Object    | Object     | Set to null when the seller is not a nominee, else fields below.                                            |
+| sell.nominee. accountType | String    | Enum       | The nominee involved in the sell. Values: GOJI, ORIGINATOR.                                                 |
+| sell.fees[]               | Array     | List       | Required when fees exist on the instrument being traded that the seller needs to pay. Otherwise leave empty.|
+
+
+### Optional Attributes
+
+| Key                       | JSON Type | Value Type | Value Description                                                             |
+|---------------------------|-----------|------------|-------------------------------------------------------------------------------|
+| buy.fees[]                | Array     | List       | Optional. Fields below detail a `FeeSymbol` registered at `POST /instrument`. |
+| buy.fees[] .symbol        | String    | FeeSymbol  | Fee type symbol registered at `POST /instrument`.                             |
+| buy.fees[] .cost.amount   | Number    | Number     | The amount to be charged associated with a specific `FeeSymbol`               |
+| buy.fees[] .cost.currency | Number    | Number     | The currency that `cost.amount` is expressed in.                              |
+| sell.fees[]               | Array     | List       | Optional. Fields below detail a `FeeSymbol` registered at `POST /instrument`. |
+| sell.fees[] .symbol       | String    | FeeSymbol  | Fee type symbol registered at `POST /instrument`.                             |
+| sell.fees[] .cost.amount  | Number    | Number     | The amount to be charged associated with a specific `FeeSymbol`               |
+| sell.fees[] .cost.currency| Number    | Number     | The currency that `cost.amount` is expressed in.                              |
+| settlementStatus          | String    | Enum       | Response only. Details the current settlement status of a trade.              |
 
 ## `POST /trades`
 ```http
@@ -54,10 +64,17 @@ X-GOJI-CLIENT-ID: 79f33f3c-86e0-4613-ba49-9fac3c6f0eab
 
 {
   "id": "cdfb86c8-1085-43ed-9839-f4c8e7267818",
+  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
+  "quantity": 1000,
+  "price": {
+    "amount": 4.99,
+    "currency": "GBP"
+  },
+  "sourceDateTime": "2019-12-09T10:21:19.453Z",
   "buy": {
     "investor": {
       "clientId": "PROP-12345",
-      "accountType": "GIA",
+      "accountType": "GIA"
     },
     "nominee": null,
     "fees": [
@@ -75,15 +92,10 @@ X-GOJI-CLIENT-ID: 79f33f3c-86e0-4613-ba49-9fac3c6f0eab
     "nominee": {
       "accountType": "ORIGINATOR"
     },
-    "fees": []
-  },
-  "price": {
-    "amount": 4.99,
-    "currency": "GBP"
-  },
-  "quantity": 1000,
-  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
-  "sourceDateTime":"2019-12-09T10:21:19.453Z"
+    "fees": [
+      
+    ]
+  }
 }
 ```
 ### Description
@@ -131,11 +143,18 @@ Content-Type: application/json
 
 {
   "id": "cdfb86c8-1085-43ed-9839-f4c8e7267818",
-  "status": "RECEIVED",
+  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
+  "quantity": 1000,
+  "price": {
+    "amount": 4.99,
+    "currency": "GBP"
+  },
+  "sourceDateTime": "2019-12-09T10:21:19.453Z",
+  "settlementStatus": "SETTLING",
   "buy": {
     "investor": {
       "clientId": "PROP-12345",
-      "accountType": "GIA",
+      "accountType": "GIA"
     },
     "nominee": null,
     "fees": [
@@ -143,7 +162,7 @@ Content-Type: application/json
         "narrative": "Stamp Duty",
         "cost": {
           "currency": "GBP",
-          "amount": 5.00
+          "amount": 5
         }
       }
     ]
@@ -153,15 +172,10 @@ Content-Type: application/json
     "nominee": {
       "accountType": "ORIGINATOR"
     },
-    "fees": []
-  },
-  "price": {
-    "amount": 4.99,
-    "currency": "GBP"
-  },
-  "quantity": 1000,
-  "instrumentSymbol": "446ca5fc-4d38-4706-a50b-5b3a64d3f703",
-  "sourceDateTime":"2019-12-09T10:21:19.453Z"
+    "fees": [
+      
+    ]
+  }
 }
 ```
 
@@ -181,7 +195,7 @@ Http Status:
 
 | Code             | Description                                      | Body       | Content-Type     |
 |------------------|--------------------------------------------------|------------|------------------|
-| 200 Created      | Trade exists and is return in the body           | Trade      | application/json |
+| 200 OK           | Trade exists and is return in the body           | Trade      | application/json |
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 | 404 Not Found    | No trade with this UUID exists                   | None       | n/a              |

--- a/source/includes/_trade-settlement.md
+++ b/source/includes/_trade-settlement.md
@@ -8,7 +8,7 @@ The API is currently under construction.
 
 Once an instrument has been created, it can then be traded. A trade can be submitted using [`POST /trades`](/#settlement-equity-post-trades).
 
-To retrieve an existing trade, the [`GET /trades/{tradeId}`](#settlement-equity-get-trades-tradeid) endpoint can be used.
+To retrieve an existing trade, the [`GET /trades/{id}`](#settlement-equity-get-trades-id) endpoint can be used.
 
 
 ## Trade Model
@@ -26,14 +26,14 @@ To retrieve an existing trade, the [`GET /trades/{tradeId}`](#settlement-equity-
 | sourceDateTime            | String    | ISO 8601   | The timestamp at which the trade was originally executed on the platform.                                   |
 | buy                       | Object    | Object     | Represents the buy-side details of a trade                                                                  |
 | buy.investor              | Object    | Object     | Set to null for non-investor, or details investor details.                                                  |
-| buy.investor. clientId    | String    | Object     | The registered clientId of the investor, i.e. PROP-12345.                                                   |
+| buy.investor. clientId    | String    | String     | The registered clientId of the investor, i.e. PROP-12345.                                                   |
 | buy.investor. accountType | String    | Enum       | Values: `GIA`, `ISA`.                                                                                       |
 | buy.nominee               | Object    | Object     | Set to null when the buyer is not a nominee, else field below.                                              |
 | buy.nominee. accountType  | String    | Enum       | The nominee involved in the buy. Values: GOJI, ORIGINATOR.                                                  |
 | buy.fees[]                | Array     | List       | Required when fees exist on the instrument being traded that the buyer needs to pay. Otherwise leave empty. |
 | sell                      | Object    | Object     | Represents the sell-side details of a trade                                                                 |
 | sell.investor             | Object    | Object     | Set to null for non-investor, or details investor details.                                                  |
-| sell.investor. clientId   | String    | Client ID  | The registered clientId of the investor, i.e. PROP-12345.                                                   |
+| sell.investor. clientId   | String    | String     | The registered clientId of the investor, i.e. PROP-12345.                                                   |
 | sell.investor. accountType| String    | Enum       | Values: `GIA`, `ISA`.                                                                                       |
 | sell.nominee              | Object    | Object     | Set to null when the seller is not a nominee, else fields below.                                            |
 | sell.nominee. accountType | String    | Enum       | The nominee involved in the sell. Values: GOJI, ORIGINATOR.                                                 |
@@ -122,12 +122,12 @@ Http Status:
 
 | HTTP Status Code | Description                                      | Body       | Content-Type     |
 |------------------|--------------------------------------------------|------------|------------------|
-| 201 Created      | Trade      created successfully                  | Trade      | application/json |
+| 201 Created      | Trade created successfully                       | Trade      | application/json |
 | 400 Bad Request  | The request was malformed.  See response body    | None       | n/a              |
 | 401 Unauthorized | No auth provided, auth failed, or not authorized | None       | n/a              |
 
 
-## `GET /trades/{tradeId}`
+## `GET /trades/{id}`
 
 ```http
 GET /trades/cdfb86c8-1085-43ed-9839-f4c8e7267818 HTTP/1.1
@@ -181,7 +181,7 @@ Content-Type: application/json
 
 ### Description
 
-Retrieves the details of an existing trade.
+Retrieves the details of an existing trade given trade `id`.
 
 ### Request
 


### PR DESCRIPTION
Clean up of all equity related docs for the following reasons:
1) defining required vs. optional attributes
2) updating some attribute definitions for clarity purposes
3) fix-up of outdated json types vs value types
4) fix-up of outdated json samples provided on docs.
5) addition of attributes that were not added until after the last docs update.