### PR TITLE
Add docker-compose for running locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.gitignore
+.gitattributes
+.editorconfig
+.idea/
+.vagrant/
+.travis.yml
+
+CHANGELOG.md
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM docker.io/ubuntu:18.04
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -yq vim software-properties-common && \
+    apt-add-repository ppa:brightbox/ruby-ng && \
+    apt-get update && \
+    apt-get install -yq ruby2.4 ruby2.4-dev && \
+    apt-get install -yq pkg-config build-essential nodejs git libxml2-dev libxslt-dev && \
+    apt-get autoremove -yq 
+
+RUN gem2.4 install --no-ri --no-rdoc bundler
+
+WORKDIR /usr/local/src
+
+COPY Gemfile .
+COPY Gemfile.lock .
+
+RUN bundle config build.nokogiri --use-system-libraries
+RUN bundle install
+
+COPY . .
+
+CMD bundle exec middleman server --watcher-force-polling --watcher-latency=1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ bundle exec middleman server
 
 # OR run this to run with vagrant
 vagrant up
+
+# OR run this to run with docker-compose
+docker-compose build
+docker-compose up
+
 ```
 
 You can now see the docs at http://localhost:4567. Whoa! That was fast!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+---
+version: '3.5'
+services:
+
+  slate:
+    image: investments.goji/goji/slate-api-docs:latest
+    build: .
+    ports:
+      - target: 4567
+        published: 4567
+    tty: true
+    volumes:
+    - type: bind
+      source: '${PWD}/source'
+      target: '/usr/local/src/source'
+      read_only: true
+


### PR DESCRIPTION
Installing ruby or rvm on fedora is a journey I don't want to experience.
Vagrant and virtual box is a bit better but still a pain.

With this anyone with docker and docker-compose can git clone and `docker-compose up` and be up and running in 2 min.