### PR TITLE
Add note that payment destination needs to be enabled before use

### DIFF
--- a/source/includes/_quickstart-settlement.md
+++ b/source/includes/_quickstart-settlement.md
@@ -165,7 +165,7 @@ To ensure the payment is processed correctly, please the following test account 
 Please note that by default the payment destination is disabled and has to be enabled by Goji before it can be used.  
 </aside>
 
-After the payment destination is enabled settle the investment.
+After the payment destination is enabled, settle the investment.
 
 The following example includes a single investment from a single Investor:
 

--- a/source/includes/_quickstart-settlement.md
+++ b/source/includes/_quickstart-settlement.md
@@ -161,7 +161,11 @@ To ensure the payment is processed correctly, please the following test account 
 `accountNumber: 00004588`
 `sortCode: 203002`
 
-Then settle the investment.
+<aside class="notice">
+Please note that by default the payment destination is disabled and have to be enabled by Goji before using it.  
+</aside>
+
+After the payment destination is enabled settle the investment.
 
 The following example includes a single investment from a single Investor:
 

--- a/source/includes/_quickstart-settlement.md
+++ b/source/includes/_quickstart-settlement.md
@@ -162,7 +162,7 @@ To ensure the payment is processed correctly, please the following test account 
 `sortCode: 203002`
 
 <aside class="notice">
-Please note that by default the payment destination is disabled and have to be enabled by Goji before using it.  
+Please note that by default the payment destination is disabled and has to be enabled by Goji before it can be used.  
 </aside>
 
 After the payment destination is enabled settle the investment.


### PR DESCRIPTION
We need to expose a test endpoint for platforms to do this themselves as ATM we need to approve a workflow manually each time.
Or we could just set new accounts to enabled if it's test/sandbox.

![image](https://user-images.githubusercontent.com/3105832/74344561-baab8680-4da4-11ea-8746-660684cd38e3.png)
