### PR TITLE
feat(wallets): update documentation for wallets

### DIFF
--- a/source/includes/_corporate-actions.md
+++ b/source/includes/_corporate-actions.md
@@ -1,4 +1,4 @@
-## <em>Corporate Actions 🚧</em>
+## *Corporate Actions*
 
 The Corporate Actions API allows an Investment Manager to perform Corporate Actions that relate to 
 [Instruments](/#settlement-equity-instruments).

--- a/source/includes/_equity-settlement.md
+++ b/source/includes/_equity-settlement.md
@@ -1,7 +1,1 @@
-# Settlement - Equity 🚧
-
-<aside class="warning">
-The equities APIs are currently in development and although best effort will be made to 
-avoid significant modification to published documentation, there is a chance some minor
- updates may take place.
-</aside>
+# Settlement - Equity

--- a/source/includes/_instruments.md
+++ b/source/includes/_instruments.md
@@ -1,4 +1,4 @@
-## <em>Instruments 🚧</em>
+## *Instruments*
 
 The Instruments API allows an Investment Manager to:
  

--- a/source/includes/_platform-payments.md
+++ b/source/includes/_platform-payments.md
@@ -1,6 +1,6 @@
 # Payments - Manager
 
-### Testing outbound payments
+## Testing outbound payments
 
 When testing outbound payments in the sandbox environment please make sure you use valid sort codes &
 account numbers as these are validated to ensure they accept faster payments prior to being sent.
@@ -16,6 +16,7 @@ Below are some valid sample details you can use:
 |166051  |  99993193|
 |166051  |  87889196|
 
+## *Managing Payment Destinations*
 
 ## `GET /platformApi/bankAccountDetails`
 ```http
@@ -24,9 +25,6 @@ GET /platformApi/bankAccountDetails HTTP/1.1
 Host: api-sandbox.goji.investments
 Content-Type: application/json
 Authorization: Basic ...
-
-
-
 ```
 
 ```http 
@@ -98,9 +96,6 @@ GET /platformApi/bankAccountDetails/{id} HTTP/1.1
 Host: api-sandbox.goji.investments
 Content-Type: application/json
 Authorization: Basic ...
-
-
-
 ```
 
 ```http 
@@ -158,151 +153,227 @@ Updates a specific set of stored account details. This will trigger an AML check
 | sortCode      | string | The sort code.      | required |
 | accountName   | string | The account name.   | required |
 
+## *Registering Companies as Wallet Holders*
 
-## `POST /platformApi/wallet/company/registration`
+## `POST /companies🚧`
 ```http
-POST /platformApi/wallet/company/registration HTTP/1.1
+POST /companies HTTP/1.1
 Host: api-sandbox.goji.investments
 Content-Type: application/json
 Authorization: Basic ...
 
 {
-  "profile": {
-    "companyName": "Company Name",
-    "address": {
-      "country": "UK",
-      "poBox": "poBox",
-      "careOf": "careOf",
-      "postalCode": "AB12CD",
-      "locality": "locality",
-      "addressLine1": "addressLine1",
-      "addressLine2": "addressLine2",
-      "region": "region"
-    },
-    "type": "ltd",
-    "companyNumber": "10965535",
-    "sicCodes": [
-      "80900"
-    ]
-  },
-  "officerList": {
-    "items": [
-      {
-        "officerRole": "director",
-        "firstName": "Name",
-        "lastName": "Surename",
-        "emailAddress": "example@example.com",
-        "address": {
-          "country": "UK",
-          "poBox": "poBox",
-          "careOf": "careOf",
-          "postalCode": "AB12CD",
-          "locality": "UK",
-          "addressLine1": "addressLine1",
-          "addressLine2": "addressLine2",
-          "region": "region"
-        },
-        "phoneNumber": "07512345678",
-        "resignedOn": "resignedOn",
-        "dateOfBirth": "1980-01-30",
-        "countryOfResidence": "countryOfResidence",
-        "appointedOn": "1999-01-30",
-        "percentageOwnership": 99
-      }
-    ]
+  "ukCompany": {
+    "number": "00000000",
+    "name": "Fake Company LIMITED"
   }
 }
+```
 
+```http 
+HTTP/1.1 201 Created
+Content-Type: application/json
+{
+  "partyId": "COM~d28360c5-07a3-4d78-ade4-bddcdd8b5502",
+  "status": "PENDING",
+  "ukCompany": {
+    "number": "00000000",
+    "name": "Fake Company LIMITED"
+  }
+}
+```
+### Description
+
+Register a company with the Goji Platform.  This allows the company to own Wallets, and send/receive money through them.
+
+The registration process is asynchronous.  When this API is first called, the `status` returned will be `PENDING`. A 
+`COMPANY_REGISTRATION_UPDATE` webhook will be used to notify completion of the registration.
+
+The registration process is partially manual, so the webhook will be dispatched significantly later than the API call, 
+so do not assume the webhook will arrive shortly after the API call. 
+
+### Request
+| Name              | Type   | Description                                        | Required |
+| ----------------- | ------ | -------------------------------------------------- | -------- |
+| ukCompany.number  | string | The Company Number registered with Companies House.| required |
+| ukCompany.name    | string | Company Name.                                      | required |
+
+### Response
+| Name              | Type   | Description                                        |
+| ----------------- | ------ | -------------------------------------------------- |
+| partyId           | string | The Party ID for this company.                     |
+| status            | string | Enum: PENDING, REGISTERED.                         |
+| ukCompany.number  | string | The Company Number registered with Companies House.|
+| ukCompany.name    | string | Company Name.                                      |
+
+## `GET /companies🚧`
+```http
+GET /companies HTTP/1.1
+Host: api-sandbox.goji.investments
+Content-Type: application/json
+Authorization: Basic ...
 ```
 
 ```http 
 HTTP/1.1 200 OK
 Content-Type: application/json
-""
+
+[
+  {
+    "partyId": "COM~d28360c5-07a3-4d78-ade4-bddcdd8b5502"
+    "ukCompany": {
+      "number": "00000000",
+      "name": "Fake Company LIMITED"
+    }
+  },
+  {
+    "partyId": "COM~0176cb07-30ba-4802-ab4a-b0835222cf5b"
+    "ukCompany": {
+      "number": "00000001",
+      "name": "Other Fake Company LIMITED"
+    }
+  }
+]
 ```
 ### Description
-Register a corporate for wallet management
-### Request
-| Name                                        | Type   | Description                                    | Required |
-| ------------------------------------------- | ------ | ---------------------------------------------- | -------- |
-| profile                                     | ref    |                                                | required |
-| profile.companyName                         | string | Company Name                                   | required |
-| profile.type                                | string | Company Type                                   | required |
-| profile.companyNumber                       | string | Company Number                                 | required |
-| profile.sicCodes                            | array  | Standard industrial classification (sic) codes | required |
-| profile.address                             | ref    |                                                | required |
-| profile.address.addressLine1                | string | Address Line 1                                 | required |
-| profile.address.addressLine2                | string | Address Line 2                                 | required |
-| profile.address.careOf                      | string | Care Of                                        | required |
-| profile.address.country                     | string | Country                                        | required |
-| profile.address.locality                    | string | Locality                                       | required |
-| profile.address.poBox                       | string | Po Box                                         | required |
-| profile.address.postalCode                  | string | Postal Code                                    | required |
-| profile.address.region                      | string | Region                                         | required |
-| officerList                                 | ref    |                                                | required |
-| officerList.items                           | array  | Officers                                       | required |
-| officerList.items.appointedOn               | string |                                                | required |
-| officerList.items.countryOfResidence        | string |                                                | required |
-| officerList.items.dateOfBirth               | string | ISO-8601 format date                           | required |
-| officerList.items.firstName                 | string |                                                | required |
-| officerList.items.lastName                  | string |                                                | required |
-| officerList.items.resignedOn                | string |                                                | |
-| officerList.items.officerRole               | string |                                                | required |
-| officerList.items.emailAddress              | string |                                                | required |
-| officerList.items.phoneNumber               | string |                                                | required |
-| officerList.items.percentageOwnership       | number |                                                | required |
-| officerList.items.address                   | ref    |                                                | required |
-| officerList.items.address.addressLine1      | string | Address Line 1                                 | required |
-| officerList.items.address.addressLine2      | string | Address Line 2                                 | required |
-| officerList.items.address.careOf            | string | Care Of                                        | required |
-| officerList.items.address.country           | string | Country                                        | required |
-| officerList.items.address.locality          | string | Locality                                       | required |
-| officerList.items.address.poBox             | string | Po Box                                         | required |
-| officerList.items.address.postalCode        | string | Postal Code                                    | required |
-| officerList.items.address.region            | string | Region                                         | required |
 
-## `POST /platformApi/wallet`
+Retrieves all companies that have been registered.
+
+### Response
+| Name              | Type   | Description                                        |
+| ----------------- | ------ | -------------------------------------------------- |
+| partyId           | string                                                      |
+| ukCompany.number  | string | The Company Number registered with Companies House.|
+| ukCompany.name    | string | Company Name                                       |
+
+## `GET /companies/{id} 🚧`
+```http
+GET /companies/COM~d28360c5-07a3-4d78-ade4-bddcdd8b5502 HTTP/1.1
+Host: api-sandbox.goji.investments
+Content-Type: application/json
+Authorization: Basic ...
+```
+
+```http 
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "partyId": "COM~d28360c5-07a3-4d78-ade4-bddcdd8b5502"
+  "ukCompany": {
+    "number": "00000000",
+    "name": "Fake Company LIMITED"
+  }
+}
+```
+### Description
+
+Retrieve details of a single company.
+
+### Response
+| Name              | Type   | Description                                        |
+| ----------------- | ------ | -------------------------------------------------- |
+| partyId           | string | Party ID for the company                           |
+| ukCompany.number  | string | The Company Number registered with Companies House.|
+| ukCompany.name    | string | Company Name                                       |
+
+## *Managing Wallets*
+
+
+## `POST /wallets 🚧`
 ```http
 
-POST /platformApi/wallet HTTP/1.1
+POST /wallets HTTP/1.1
 Host: api-sandbox.goji.investments
 Content-Type: application/json
 Authorization: Basic ...
 
 {
+  "ownerPartyId": "COM~d28360c5-07a3-4d78-ade4-bddcdd8b5502",
   "walletName" : "Housing Project 22"
 }
 
 ```
 
 ```http 
-HTTP/1.1 202 OK
+HTTP/1.1 202 Accepted
 Content-Type: application/json
 
 {
-  "id" : "3d9ca033-eb05-459f-9f70-1139d2e2b213"
+  "id" : "3d9ca033-eb05-459f-9f70-1139d2e2b213",
+  "ownerPartyId": "COM~d28360c5-07a3-4d78-ade4-bddcdd8b5502",
+  "walletName" : "Housing Project 22"
 }
 ```
-<aside class="notice">
-Prior to creating a wallet you need to have registered your company as the wallet holder using /wallet/company/registration
-</aside>
+
+ℹ️ _Prior to creating a Wallet, the company who owns the money in the Wallet must be registered using [`POST /companies`](#payments-manager-post-companies)_
 
 ### Description
-Create a wallet
+Creates a Wallet. The Wallet creation will not happen immediately. The `WALLET_CREATED` webhook will be used to notify
+you of the Wallet creation completing, including the Bank Account Number and Sort Code.
+
 ### Request
-| Name       | Type   | Description     | Required |
-| ---------- | ------ | --------------- | -------- |
-| walletName | string | New wallet name | required |
+| Name         | Type   | Description                           | Required |
+| ------------ | ------ | ------------------------------------- | -------- |
+| ownerPartyId | string | The PartyId that will own the Wallet. | required |
+| walletName   | string | New wallet name                       | required |
 
 ### Response
-| Name       | Type   | Description                                   |
-| ---------- | ------ | --------------------------------------------- |
-| id         | string | The unique identifier for the created wallet  |
+| Name         | Type   | Description                           |
+| ------------ | ------ | ------------------------------------- |
+| id           | string | The unique identifier for the Wallet. |
+| ownerPartyId | string | The PartyId that will own the Wallet. |
+| walletName   | string | Wallet name.                          |
 
-## `GET /platformApi/wallet/{id}`
+
+## `GET /wallets 🚧`
 ```http
 
-GET /platformApi/wallet/{id} HTTP/1.1
+GET /wallets HTTP/1.1
+Host: api-sandbox.goji.investments
+Content-Type: application/json
+Authorization: Basic ...
+```
+
+```http 
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "id" : "walletId",
+    "bankAccountDetailsId" : "bankAccountDetailsId",
+    "bankDetails" : {
+      "accountName": "Housing Project 22",
+      "accountNumber": "00000000",
+      "sortCode": "000000"
+    },
+    "balance" : {
+      "currency" : "GBP"
+      "amount" : 10.45
+    }
+  }
+]
+```
+### Description
+List of wallet details
+### Response
+| Name                        | Type   | Description                                      |
+| --------------------------- | ------ | ------------------------------------------------ |
+| id                          | string | The ID of the wallet                             |
+| bankAccountDetailsId        | string | The bank account details ID                      |
+| bankDetails                 | ref    | The bank details for the wallet                  |
+| bankDetails.accountName     | string | The account name for use when depositing money   |
+| bankDetails.accountNumber   | string | The account number to use when depositing money  |
+| bankDetails.sortCode        | string | The sort code to use when depositing money       |
+| balance                     | ref    | The total cash balance for the wallet            |
+| balance.amount              | number | The amount.                                      |
+| balance.currency            | string | The ISO 4217 three character codes eg 'GBP'      |
+
+## `GET /wallets/{id} 🚧`
+```http
+
+GET /wallets/3d9ca033-eb05-459f-9f70-1139d2e2b213 HTTP/1.1
 Host: api-sandbox.goji.investments
 Content-Type: application/json
 Authorization: Basic ...
@@ -314,12 +385,12 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "id" : "walletId",
+  "id" : "3d9ca033-eb05-459f-9f70-1139d2e2b213",
   "bankAccountDetailsId" : "bankAccountDetailsId",
   "bankDetails" : {
-    "accountName": "accountName",
-    "accountNumber": "accountNumber",
-    "sortCode": "sortCode"
+    "accountName": "Housing Project 22",
+    "accountNumber": "00000000",
+    "sortCode": "000000"
   },
   "balance" : {
     "amount" : 10.45,
@@ -342,112 +413,36 @@ Wallet Details
 | balance.amount              | number | The amount.                                      |
 | balance.currency            | string | The ISO 4217 three character codes eg 'GBP'      |
 
-## `GET /platformApi/wallets`
+
+## `POST /wallets/{id}/payment 🚧`
 ```http
 
-GET /platformApi/wallets HTTP/1.1
-Host: api-sandbox.goji.investments
-Content-Type: application/json
-Authorization: Basic ...
-
-```
-
-```http 
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-[
-  {
-    "id" : "walletId",
-    "bankAccountDetailsId" : "bankAccountDetailsId",
-    "bankDetails" : {
-      "accountName": "accountName",
-      "accountNumber": "accountNumber",
-      "sortCode": "sortCode"
-    },
-    "balance" : {
-      "amount" : 10.45,
-      "currency" : "GBP"
-    }
-  }
-]
-```
-### Description
-List of wallet details
-### Response
-| Name                        | Type   | Description                                      |
-| --------------------------- | ------ | ------------------------------------------------ |
-| id                          | string | The ID of the wallet                             |
-| bankAccountDetailsId        | string | The bank account details ID                      |
-| bankDetails                 | ref    | The bank details for the wallet                  |
-| bankDetails.accountName     | string | The account name for use when depositing money   |
-| bankDetails.accountNumber   | string | The account number to use when depositing money  |
-| bankDetails.sortCode        | string | The sort code to use when depositing money       |
-| balance                     | ref    | The total cash balance for the wallet            |
-| balance.amount              | number | The amount.                                      |
-| balance.currency            | string | The ISO 4217 three character codes eg 'GBP'      |
-
-## `GET /platformApi/wallet/{id}/balance`
-
-```http
-
-GET /platformApi/wallet/{id}/balance HTTP/1.1
-Host: api-sandbox.goji.investments
-Content-Type: application/json
-Authorization: Basic ...
-
-```
-
-```http 
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "walletId" : "walletId",
-  "balance" : {
-    "amount" : 10.45,
-    "currency" : "GBP"
-  }
-}
-```
-### Description
-Get the total balance for a wallet
-### Response
-| Name                 | Type   | Description                                   |
-| -------------------- | ------ | --------------------------------------------- |
-| walletId             | string | The ID of the wallet                          |
-| balance              | ref    | The total cash balance for the wallet         |
-| balance.amount       | number | The amount.                                   |
-| balance.currency     | string | The ISO 4217 three character codes eg 'GBP'   |
-
-## `POST /platformApi/wallet/{id}/payment`
-```http
-
-POST /platformApi/wallet/{id}/payment HTTP/1.1
+POST /wallets/{id}/payment HTTP/1.1
 Host: api-sandbox.goji.investments
 Content-Type: application/json
 Authorization: Basic ...
 
 {
-  "destinationBankAccountId" : "walletName",
+  "destinationBankAccountId" : "03946a54-6b4f-4bae-897d-6ee2baf0e848",
   "amount" : {
-    "amount" : 10.45,
-    "currency" : "GBP"
+    "currency" : "GBP",
+    "amount" : 10.45
   },
-  "reference" : "reference",
-  "narrative" : "narrative"
+  "reference" : "ABC1234567",
+  "narrative" : "Moving to operating account"
 }
 
 ```
 
 ```http 
-HTTP/1.1 202 OK
+HTTP/1.1 202 Accepted
 Content-Type: application/json
 
-""
 ```
 ### Description
-Create a payment instruction from a wallet
+Create a payment instruction from a wallet.  Before instructing a payment, the destination bank account
+must first be registered using [`POST /platformApi/bankAccountDetails`](/#payments-manager-post-platformapi-bankaccountdetails).
+
 ### Request
 | Name                          | Type   | Description                                 | Required |
 | ----------------------------- | ------ | ------------------------------------------- | -------- |
@@ -458,11 +453,11 @@ Create a payment instruction from a wallet
 | reference                     | string | The bank reference used for the transfer    | required |
 | narrative                     | string | The reason for the wallet transfer          |          |
 
-## `GET /platformApi/wallet/{id}/transactions/year/{year}/month/{month}`
+## `GET /wallets/{id}/transactions/year/{year}/month/{month} 🚧`
 
 ```http
 
-GET /platformApi/wallet/{id}/transactions/year/{year}/month/{month} HTTP/1.1
+GET /wallets/{id}/transactions/year/{year}/month/{month} HTTP/1.1
 Host: api-sandbox.goji.investments
 Content-Type: application/json
 Authorization: Basic ...

--- a/source/includes/_trade-settlement.md
+++ b/source/includes/_trade-settlement.md
@@ -1,4 +1,4 @@
-## <em>Trade Settlement 🚧</em>
+## *Trade Settlement*
 
 The Trade Settlement API allows an Investment Manager to report trades which require settlement.
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -63,7 +63,7 @@ Register a webhook url.
 | url   | string | The url as specified in the request. |
 | secret   | string | The webhook secret that should be used to check the validity of webhooks received (see [Webhooks authentication](#webhooks-authentication) for full details). |
 
-## Webhook Types
+## *Webhook Types*
 
 When certain events are triggered in the Goji system, a call can be made to your system to inform you of this event.
 
@@ -82,8 +82,8 @@ The URL to be called is configured as part of the onboarding process.
 The webhook `POST` body will be in the following format.
 The following event `type`s will be supported, along with the content as `JSON`.
 
->INVESTOR_PERSONAL_DETAILS_REGISTERED
-><br>This is fired whenever personal details are registered.
+## INVESTOR_PERSONAL_DETAILS_REGISTERED
+This is fired whenever personal details are registered.
 
 ```json
 {
@@ -97,8 +97,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ````
 
->INVESTOR_CREATED
-><br>This is fired whenever a new investor is registered.
+## INVESTOR_CREATED
+This is fired whenever a new investor is registered.
 
 ```json
 {
@@ -124,8 +124,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->INVESTOR_KYC_STATUS_CHANGE
-><br>This is fired whenever an investor's KYC status changes eg from `REFERRED` to `VERIFIED`.
+## INVESTOR_KYC_STATUS_CHANGE
+This is fired whenever an investor's KYC status changes eg from `REFERRED` to `VERIFIED`.
 
 ```json
 {
@@ -134,8 +134,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->INVESTOR_FUNDS_RECEIVED
-><br>This is fired whenever investor funds are cleared into their account eg for a bank transfer.
+## INVESTOR_FUNDS_RECEIVED
+This is fired whenever investor funds are cleared into their account eg for a bank transfer.
 
 ```json
 {
@@ -154,8 +154,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->ISA_AUTO_REPAIRED
-><br>This is fired whenever an oversubscribed ISA has been auto repaired. Oversubscription happens when an investor deposits more than their allowed subscription limit. The overflowing amount will be automatically moved to the investment account.
+## ISA_AUTO_REPAIRED
+This is fired whenever an oversubscribed ISA has been auto repaired. Oversubscription happens when an investor deposits more than their allowed subscription limit. The overflowing amount will be automatically moved to the investment account.
 
 ```json
 {
@@ -167,8 +167,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->INVESTOR_FUNDS_WITHDRAWN
-><br>This is fired whenever an investor withdraws funds.
+## INVESTOR_FUNDS_WITHDRAWN
+This is fired whenever an investor withdraws funds.
 
 ```json
 {
@@ -182,8 +182,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->INVESTMENT_QUEUED
-><br>This is fired whenever an investment is queued. Bond Management API only.
+## INVESTMENT_QUEUED
+This is fired whenever an investment is queued. Bond Management API only.
 
 ```json
 {
@@ -197,8 +197,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->INVESTMENT_FULFILLED
-><br>This is fired whenever an investment is fulfilled. Bond Management API only.
+## INVESTMENT_FULFILLED
+This is fired whenever an investment is fulfilled. Bond Management API only.
 
 ```json
 {
@@ -207,8 +207,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->TRANSFER_IN_CREATED
-><br>This is fired whenever a transfer in is created.
+## TRANSFER_IN_CREATED
+This is fired whenever a transfer in is created.
 
 ```json
 {
@@ -217,8 +217,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->TRANSFER_OUT_CREATED
-><br>This is fired whenever a transfer out is requested.
+## TRANSFER_OUT_CREATED
+This is fired whenever a transfer out is requested.
 
 ```json
 {
@@ -280,10 +280,11 @@ The following event `type`s will be supported, along with the content as `JSON`.
     },
     "dateOfFirstSubscriptionInCurrentYear": "2017-12-12"
   }
+}
 ```
 
->TRANSFER_OUT_COMPLETED
-><br>This is fired whenever a transfer out is completed.
+## TRANSFER_OUT_COMPLETED
+This is fired whenever a transfer out is completed.
 
 ```json
 {
@@ -345,10 +346,11 @@ The following event `type`s will be supported, along with the content as `JSON`.
     },
     "dateOfFirstSubscriptionInCurrentYear": "2017-12-12"
   }
+}
 ```
 
->TRANSFER_IN_FUNDS_RECEIVED
-><br>This is fired whenever the funds for a transfer in are received.
+## TRANSFER_IN_FUNDS_RECEIVED
+This is fired whenever the funds for a transfer in are received.
 
 ```json
 {
@@ -361,8 +363,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->ISA_PROVISIONALLY_OPENED
-><br>This is fired whenever an ISA is opened.
+## ISA_PROVISIONALLY_OPENED
+This is fired whenever an ISA is opened.
 
 ```json
 {
@@ -370,8 +372,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->INVESTMENT_PAYOUT_EVENT
-><br>This is fired whenever a repayment is distributed to an investor's account. Bond Management API only.
+## INVESTMENT_PAYOUT_EVENT
+This is fired whenever a repayment is distributed to an investor's account. Bond Management API only.
 
 ```json
 {
@@ -394,8 +396,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->FUNDS_REQUESTED
-><br>This is fired whenever repayment funds are requested from the investment manager. Bond Management API only.
+## FUNDS_REQUESTED
+This is fired whenever repayment funds are requested from the investment manager. Bond Management API only.
 
 ```json
 {
@@ -419,8 +421,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->FUNDS_RECEIVED
-><br>This is fired whenever repayment funds are received from the investment manager.
+## FUNDS_RECEIVED
+This is fired whenever repayment funds are received from the investment manager.
 
 ```json
 {
@@ -432,8 +434,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->BANK_ACCOUNT_DETAILS_STATUS_CHANGED
-><br>This is fired whenever a set of bank account details are "ENABLED"/"DISABLED", as displayed by their status.
+## BANK_ACCOUNT_DETAILS_STATUS_CHANGED
+This is fired whenever a set of bank account details are "ENABLED"/"DISABLED", as displayed by their status.
 
 ```json
 {
@@ -445,8 +447,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->WALLET_CREATED
-><br>This is fired whenever a wallet is created.
+## WALLET_CREATED
+This is fired whenever a wallet is created.
 
 ```json
 {
@@ -455,22 +457,13 @@ The following event `type`s will be supported, along with the content as `JSON`.
     "id" : "f5d57a4a-a6cc-4b5f-8ef0-09e09b02de28",
     "accountName" : "string",
     "accountNumber" : "string",
-    "sortCode" : "string",
+    "sortCode" : "string"
   }
 }
 ```
 
->WALLET_REGISTERED
-><br>This is fired whenever setup management of wallet is done.
-
-```json
-{
-  "companyName" : "string",
-}
-```
-
->WALLET_FUNDS_RECEIVED
-><br>This is fired whenever funds are received in a wallet.
+## WALLET_FUNDS_RECEIVED
+This is fired when funds are received into a wallet.
 
 ```json
 {
@@ -489,8 +482,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 ```
 
 
->WALLET_TRANSFER_CLEARED
-><br>This is fired when a wallet transfer is completed. This Webhook is currently not in use.
+## WALLET_TRANSFER_CLEARED
+This is fired when a wallet transfer is completed. This Webhook is currently not in use.
 
 ```json
 {
@@ -499,7 +492,7 @@ The following event `type`s will be supported, along with the content as `JSON`.
     "bankDetails" : {
       "accountName" : "string",
       "accountNumber" : "string",
-      "sortCode" : "string",
+      "sortCode" : "string"
     }
   },
   "sourceWallet" : {
@@ -507,7 +500,7 @@ The following event `type`s will be supported, along with the content as `JSON`.
     "bankDetails" : {
       "accountName" : "string",
       "accountNumber" : "string",
-      "sortCode" : "string",
+      "sortCode" : "string"
     }
   },
   "amount" : {
@@ -520,8 +513,8 @@ The following event `type`s will be supported, along with the content as `JSON`.
 }
 ```
 
->TRADE_SETTLEMENT
-><br>This event is fired when a trade request (available as part of the Equities API) has reached a terminal state. 
+TRADE_SETTLEMENT
+This event is fired when a trade request (available as part of the Equities API) has reached a terminal state. 
 E.g. settles successfully
 
 ```json
@@ -569,10 +562,10 @@ E.g. settles successfully
 }
 ```
 
->DIVIDEND_UPDATE
-><br>This event is fired two times in the lifecycle of a dividend post request. 
-(1) once funds have been received to distribute to investors 'DISTRIBUTING' 
-(2) once distribution of the dividend is 'COMPLETE'
+## DIVIDEND_UPDATE
+This event is fired two times in the lifecycle of a dividend post request. 
+1. once funds have been received to distribute to investors 'DISTRIBUTING' 
+2. once distribution of the dividend is 'COMPLETE'
 
 ```json
 {
@@ -610,8 +603,8 @@ E.g. settles successfully
 }
 ```
 
->BATCH_UPDATE
-><br>This event is fired when an update related to a bulk payment request occurs. E.g. the bulk payment is now complete.
+## BATCH_UPDATE
+This event is fired when an update related to a bulk payment request occurs. E.g. the bulk payment is now complete.
 
 ```json
 {
@@ -651,14 +644,14 @@ E.g. settles successfully
 }
 ```
 
->ACCOUNT_FEE_PROCESSED
-><br>This is fired when account fees have been processed
+## ACCOUNT_FEE_PROCESSED
+This is fired when account fees have been processed
 
 ```json
 {
   "investorId": "string",
   "dateTime": "2017-12-12T14:34:23",
-  "account": "string"
+  "account": "string",
   "amount" : {
     "amount": 0.00,
     "currency": "GBP"
@@ -666,5 +659,19 @@ E.g. settles successfully
   "type": "FEES",
   "reference": "string",
   "clearedDateTime": "2017-12-12T14:34:23"
+}
+```
+
+## COMPANY_REGISTRATION_UPDATE
+This is fired when the status of the company registration state changes. 
+
+```json
+{
+  "partyId": "COM~d28360c5-07a3-4d78-ade4-bddcdd8b5502",
+  "status": "REGISTERED",
+  "ukCompany": {
+    "number": "00000000",
+    "name": "Fake Company LIMITED"
+  }
 }
 ```


### PR DESCRIPTION
Changes:

 * Dropped `/platformApi` from all endpoints we're changing.
 * Removed `/platformApi/wallet/company/registration` and replaced with the `/companies` resource.  Only requires the company number (from Companies House) and the company name (not really required, but might be useful?)
 * Standardised on pluralised REST resources for `/companies` and `/wallets`.
 * When creating a company, a `PartyId` is returned, of the form `PREFIX~UUID`.  This can be used anywhere a `PartyId` is required, i.e. when registering for a wallet - likely to include more places as we talk about 'parties' instead of 'investors', etc.  
 * Removed 🚧 symbols from equity trade settlement APIs
 * Added to the changed wallet APIs, as they're not yet implemented.
 * Improved formatting of sidebar under the Payments - Manager section. 
 * Replaced some HTML with Markdown.
 * Made the examples more realistic, i.e. rather than `"id": "walletId"` it now says `"id": "e2fe0d1e-977c-44c3-83cd-bb3d6a97a192"`
 * Tidied white space.
 * Removed `GET /wallet/{id}/balance` as it's returned from `GET /wallets/{id}`

Haven't changed, but think we should:

 * `GET /wallets/{id}/transactions/year/{year}/month/{month}`.  Seems like we can drop `/year/` and `/month` and make this a little more sane?  
 * Didn't drop `/platformApi` from the `/bankAccountDetails` endpoints because I've not touched them.