### PR TITLE
Update the link for registering payment destination in quickguide

### DIFF
--- a/source/includes/_quickstart-settlement.md
+++ b/source/includes/_quickstart-settlement.md
@@ -152,7 +152,7 @@ First register the investment product:
 
 Next, register a payment destination. This is where the funds will be sent.
 
-[POST https://api-sandbox.goji.investments/platformApi/settlement/payment-destination](/#post-settlement-payment-destination)
+[POST https://api-sandbox.goji.investments/platformApi/bankAccountDetails](/#payments-manager-post-platformapi-bankaccountdetails)
 
 This returns a payment destination ID which must be saved and used for the subsequent call.
 

--- a/source/includes/_quickstart-settlement.md
+++ b/source/includes/_quickstart-settlement.md
@@ -145,7 +145,6 @@ First register the investment product:
 {
   "accountName": "Account name",
   "accountNumber": "123456",
-  "reference": "Bank ref",
   "sortCode": "112233"
 }
 ```


### PR DESCRIPTION
`settlement/payment-destination` is deprecated.
`/bankAccountDetails` is the new one (for a long time already)


BEFORE: 
![image](https://user-images.githubusercontent.com/3105832/82199052-167e3200-98f5-11ea-98f2-5343852c17ca.png)


AFTER:
![image](https://user-images.githubusercontent.com/3105832/82198982-fd758100-98f4-11ea-91fe-c249bb2b5a9b.png)

