### PR TITLE
Fix broken links in quickstart guides

### DIFF
--- a/source/includes/investor-payments.md.erb
+++ b/source/includes/investor-payments.md.erb
@@ -36,7 +36,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -92,7 +92,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -153,7 +153,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -217,7 +217,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -249,7 +249,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -281,7 +281,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -317,7 +317,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -362,7 +362,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -406,7 +406,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -458,7 +458,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 
@@ -518,6 +518,8 @@ Transfer cash to another account.
 ### Description
 Simulate depositing cash into any bank account managed on the Goji platform.
 
+For an investor account the payment reference must start with `ISA` if the funds are to be deposited to the ISA account.
+
 <aside class="notice">
 Please note this is a test endpoint and is only available in the sandbox environment.
 </aside>
@@ -560,7 +562,7 @@ Content-Type: application/json
 ```
 
 ```http
-HTTP/1.1 400 
+HTTP/1.1 400
 Content-Type: application/json
 
 {
@@ -573,7 +575,7 @@ Content-Type: application/json
 }
 ```
 ```http
-HTTP/1.1 400 
+HTTP/1.1 400
 Content-Type: application/json
 
 {
@@ -607,7 +609,7 @@ Authorization: Basic ...
 
 ```
 
-```http 
+```http
 HTTP/1.1 201 OK
 Content-Type: application/json
 
@@ -621,7 +623,7 @@ Content-Type: application/json
    "reference": "reference",
    "status": "status"
  }
- 
+
 ```
 ### Description
 Extract a fee from a specified investor's account cash balance

--- a/source/includes/quickstart-settlement.md.erb
+++ b/source/includes/quickstart-settlement.md.erb
@@ -30,7 +30,7 @@ In Sandbox, `Basic Auth` can be used to help you prototype integrations.
 
 Webhooks are fired to inform you whenever specific events are fired in the Goji Platform.
 
-You can register a URL to receive webhooks by calling [POST https://api-sandbox.goji.investments/platformApi/webhooks](/#post-webhooks) with example `POST` body:
+You can register a URL to receive webhooks by calling [POST https://api-sandbox.goji.investments/platformApi/webhooks](/#webhooks-post-webhooks) with example body:
 
 ## Creating an Investor
 
@@ -67,16 +67,16 @@ You can register a URL to receive webhooks by calling [POST https://api-sandbox.
 
 To create an Investor, the Investor must first agree to the Terms and Conditions, and optionally the ISA declaration if the Investor is opening an ISA.
 
-Goji supports hosting the Terms and Conditions, retrieved by calling [GET https://api-sandbox.goji.investments/platformApi/terms](/#get-terms).
+Goji supports hosting the Terms and Conditions, retrieved by calling [GET https://api-sandbox.goji.investments/platformApi/terms](/#investors-get-terms).
 
-The ISA Declaration can be retrieved by calling [GET https://api-sandbox.goji.investments/platformApi/isaDeclaration](/#get-isadeclaration)
+The ISA Declaration can be retrieved by calling [GET https://api-sandbox.goji.investments/platformApi/isaDeclaration](/#investors-get-platformapi-isadeclaration)
 
-An Investor is created by posting to [https://api-sandbox.goji.investments/platformApi/investors](/#post-investors) with example `POST` body:
+An Investor is created by calling [POST https://api-sandbox.goji.investments/platformApi/investors](/#investors-post-platformapi-investors) with example body:
 
 The Goji Platform will generate a `clientId` which should be saved as this is used for subsequent calls.
 
 ## Checking the KYC details
-Once the Investor has been created, a KYC check is done in the background and the status can be checked by calling [GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/kyc](/#get-investors-clientid-kyc)
+Once the Investor has been created, a KYC check is done in the background and the status can be checked by calling [GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/kyc](/#investors-get-platformapi-investors-clientid-kyc)
 
 In the sandbox environment, all Investors are considered verified unless the `lastName` contains `referred`.
 
@@ -99,13 +99,13 @@ In the sandbox environment, all Investors are considered verified unless the `la
 Once an Investor is KYC approved, funds can be deposited.
 
 ### An Investor's Bank Details
-The Investor's unique bank details for depositing funds can be retrieved by calling: [GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/bankTransferDetails](/#get-investors-clientid-banktransferdetails)
+The Investor's unique bank details for depositing funds can be retrieved by calling: [GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/bankTransferDetails](/#payments-investors-get-platformapi-investors-clientid-banktransferdetails)
 
 ### An ISA Investor's Bank Details
-For an ISA account, use: [GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/bankTransferDetails/isa](/#get-investors-clientid-banktransferdetails-isa)
+For an ISA account, use: [GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/bankTransferDetails/isa](/#payments-investors-get-platformapi-investors-clientid-banktransferdetails-isa)
 
 ### Testing
-You can simulate depositing funds by calling [POST https://api-sandbox.goji.investments/platformApi/test/payment](/#post-test-payment) with a example `POST` body:
+You can simulate depositing funds by calling [POST https://api-sandbox.goji.investments/platformApi/test/account/topup](/#payments-investors-post-test-account-topup).
 
 The payment reference must start with `ISA` if the funds are to be deposited to the ISA account.
 
@@ -114,7 +114,7 @@ Once funds are deposited, a webhook will be fired with type `INVESTOR_FUNDS_RECE
 ### An Investor's Balance
 An Investor's balance can be queried by calling:
 
-[GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/accounts/balances](/#get-investors-clientid-accounts-balances)
+[GET https://api-sandbox.goji.investments/platformApi/investors/{clientId}/accounts/balances](/#payments-investors-get-platformapi-investors-clientid-accounts-balances)
 
 ## Settling an Investment
 Once an Investor has a cash balance, the funds can be invested by calling the settlement API. This will move the funds from one or more investors to a predetermined account. This account may be with the Investment Manager, a Solicitor or the borrower directly.
@@ -133,7 +133,7 @@ Once an Investor has a cash balance, the funds can be invested by calling the se
 
 First register the investment product:
 
-[POST https://api-sandbox.goji.investments/platformApi/settlement/product](/#post-settlement-product)
+[POST https://api-sandbox.goji.investments/platformApi/settlement/product](/#settlement-debt-post-platformapi-settlement-product)
 
 *This can be reused multiple times.*
 
@@ -188,11 +188,11 @@ The following example includes a single investment from a single Investor:
 }
 ```
 
-[POST https://api-sandbox.goji.investments/platformApi/settlement/tranche](/#post-settlement-tranche)
+[POST https://api-sandbox.goji.investments/platformApi/settlement/tranche](/#settlement-debt-post-platformapi-settlement-tranche)
 
 The investor's investment can be queried by calling:
 
-[https://api-sandbox.goji.investments/platformApi/settlement/investors/{clientId}/accounts/{accountType}/investments](/#get-settlement-investors-clientid-accounts-accounttype-investments)
+[GET https://api-sandbox.goji.investments/platformApi/settlement/investors/{clientId}/accounts/{accountType}/investments](/#settlement-debt-get-platformapi-settlement-investors-clientid-accounts-accounttype-investments)
 
 ## Repaying the Investment
 
@@ -208,7 +208,7 @@ The investor's investment can be queried by calling:
 
 To record a repayment against an investment, firstly generate a unique reference that will be used when sending the funds to the Goji Platform.
 
-[GET https://api-sandbox.goji.investments/platformApi/settlement/repayment/reference](/#get-settlement-repayment-reference)
+[GET https://api-sandbox.goji.investments/platformApi/settlement/repayment/reference](/#settlement-debt-get-platformapi-settlement-repayment-reference)
 
 This will return the account details to use when sending the funds to repay:
 
@@ -236,7 +236,7 @@ Once the funds have been sent to this destination and the funds have cleared, ca
 }
 ```
 
-[POST https://api-sandbox.goji.investments/platformApi/settlement/repayment](/#post-settlement-repayment)
+[POST https://api-sandbox.goji.investments/platformApi/settlement/repayment](/#settlement-debt-post-platformapi-settlement-repayment)
 
 This will ensure that `£123.45` has been deposited with reference `some-ref` which was generated by the previous call. If this check passes, the funds will be credited to the Investor and recorded as an interest repayment against `client-investment-1`.
 
@@ -270,10 +270,10 @@ An Investor can withdraw funds by firstly registering bank account details:
 
 <%= partial "partials/valid_test_account_numbers" %>
 
-[POST https://api-sandbox.goji.investments/platformApi/investors/{clientId}/bankDetails](/#post-investors-clientid-bankdetails)
+[POST https://api-sandbox.goji.investments/platformApi/investors/{clientId}/bankDetails](#payments-investors-post-platformapi-investors-clientid-bankdetails)
 
 ### Process Withdrawal
 
 Then the funds can be withdrawn:
 
-[https://api-sandbox.goji.investments/platformApi/investors/{clientId}/accounts/{accountType}/withdrawal](/#post-investors-clientid-accounts-accounttype-withdrawal)
+[POST https://api-sandbox.goji.investments/platformApi/investors/{clientId}/accounts/{accountType}/withdrawal](/#payments-investors-post-platformapi-investors-clientid-accounts-accounttype-withdrawal)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -255,9 +255,6 @@ In order to complete the email integration you will need to:
 
 In order to permission our email provider (Mandrill) to send emails using your domain you will be required to make the following DNS changes:
 
-##Valid test account numbers
-<%= partial "partials/valid_test_account_numbers" %>
-
 ###DKIM
 
 `v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;`
@@ -280,5 +277,8 @@ If you already have a `TXT` record with SPF information, you'll need to add Mand
 
 ###Domain Ownership Verification
 Additionally, we need to send a verification email to verify your ownership of the domain. Please let us know which email address to send this to and when you receive the email from Mandrill, please forward it to [techsupport@goji.investments](mailto:techsupport@goji.investments)
+
+##Valid test account numbers
+<%= partial "partials/valid_test_account_numbers" %>
 
 # Quickstart Guides


### PR DESCRIPTION
Also correct positioning of `Valid test account numbers` as it was in the middle of "emails".

