### PR TITLE
Add valid examples for migrating investors

### DIFF
--- a/source/includes/_investors.md
+++ b/source/includes/_investors.md
@@ -1997,7 +1997,7 @@ Lists all transfers out for all investors.
 
 If you are migrating your existing investors over to Goji, then you need to onboard the existing investors using the dedicated [investor migration endpoint](#investors-post-platformapi-migrate) and include `migrationDetails` data.
 
-The `migrationDetails` allows the platform to provide an existing investor ID where applicable and provide the dilligence status as agreed with Goji before migration takes place. 
+The `migrationDetails` allows the platform to provide an existing investor ID where applicable and provide the diligence status as agreed with Goji before migration takes place. 
 
 ### Upgrading investors currently using the ISA Administration API
 
@@ -2015,6 +2015,53 @@ Any existing ISA data is preserved.
 ## `POST /platformApi/migrate`
 
 ```http
+POST /platformApi/investors HTTP/1.1
+Host: api-sandbox.goji.investments
+Content-Type: application/json
+Authorization: Basic ...
+
+{
+  "title": "MS",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "address": {
+    "country": "GBR",
+    "lineOne": "1 The High Street",
+    "lineTwo": "",
+    "lineThree": "",
+    "postcode": "AA1 1AA",
+    "townCity": "London",
+    "region": "Greater London"
+  },
+  "nationalInsuranceNumber": "MG442319A",
+  "accountTypes": [
+    "GOJI_INVESTMENT",
+    "ISA"
+  ],
+  "entityType": "INDIVIDUAL",
+  "employmentDetails": {
+    "jobTitle": "Accountant",
+    "employmentStatus": "EMPLOYED_FULL_TIME"
+  },
+  "nationalities": [
+    {"nationality": "GB"},
+    {"nationality": "CH"}
+  ],
+  "dateOfBirth": "1990-01-19",
+  "migrationDetails": {
+    "existingClientId": "existingClientId",
+    "diligenceMigrationOption": "FULL_CHECK",
+    "previousCheckDate": "2000-01-23"
+  },
+  "investorDeclarationType": "RESTRICTED",
+  "contactDetails": {
+    "emailAddress": "example@example.com",
+    "telephoneNumber": "07123456789"
+  }
+}
+```
+
+```http
 
 POST /platformApi/investors HTTP/1.1
 Host: api-sandbox.goji.investments
@@ -2022,48 +2069,43 @@ Content-Type: application/json
 Authorization: Basic ...
 
 {
-  "lastName" : "lastName",
-  "corporateDetails" : {
-    "companyType" : "companyType",
-    "registrationNumber" : "registrationNumber",
-    "companyName" : "companyName"
+  "title": "MS",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "corporateDetails": {
+    "companyType": "LLC",
+    "registrationNumber": "AB123456",
+    "companyName": "Fake company"
   },
-  "address" : {
-    "country" : "country",
-    "lineTwo" : "lineTwo",
-    "townCity" : "townCity",
-    "postcode" : "postcode",
-    "lineOne" : "lineOne",
-    "lineThree" : "lineThree",
-    "region" : "region"
+  "address": {
+    "country": "GBR",
+    "lineOne": "1 The High Street",
+    "lineTwo": "",
+    "lineThree": "",
+    "postcode": "AA1 1AA",
+    "townCity": "London",
+    "region": "Greater London"
   },
-  "entityType" : "INDIVIDUAL",
-  "employmentDetails" : {
-    "jobTitle" : "jobTitle",
-    "employmentStatus" : "EMPLOYED_FULL_TIME"
-  },
-  "nationalities" : [ {
-    "nationality" : "GB"
-  }, {
-    "nationality" : "CH"
-  } ],
-  "dateOfBirth" : "2000-01-23",
-  "migrationDetails" : {
-    "existingClientId" : "existingClientId",
+  "accountTypes": [
+    "GOJI_INVESTMENT",
+  ],
+  "entityType": "CORPORATE",
+  "nationalities": [
+    {"nationality": "GB"},
+    {"nationality": "CH"}
+  ],
+  "dateOfBirth": "1990-01-19",
+  "migrationDetails": {
+    "existingClientId": "existingClientId",
     "diligenceMigrationOption": "FULL_CHECK",
     "previousCheckDate": "2000-01-23"
   },
-  "title" : "MISS",
-  "investorDeclarationType" : "RESTRICTED",
-  "contactDetails" : {
-    "emailAddress" : "emailAddress",
-    "telephoneNumber" : "telephoneNumber"
-  },
-  "firstName" : "firstName",
-  "nationalInsuranceNumber" : "nationalInsuranceNumber",
-  "accountTypes" : [ { }, { } ]
+  "investorDeclarationType": "HIGH_NET_WORTH",
+  "contactDetails": {
+    "emailAddress": "example@example.com",
+    "telephoneNumber": "07123456789"
+  }
 }
-
 ```
 
 ```http 
@@ -2071,41 +2113,51 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "lastName" : "lastName",
-  "corporateDetails" : {
-    "companyType" : "companyType",
-    "registrationNumber" : "registrationNumber",
-    "companyName" : "companyName"
+  "title": "MS",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "corporateDetails": {
+    "companyType": "LLC",
+    "registrationNumber": "AB123456",
+    "companyName": "Fake company"
   },
-  "clientId" : "clientId",
-  "address" : {
-    "country" : "country",
-    "lineTwo" : "lineTwo",
-    "townCity" : "townCity",
-    "postcode" : "postcode",
-    "lineOne" : "lineOne",
-    "lineThree" : "lineThree",
-    "region" : "region"
+  "address": {
+    "country": "GBR",
+    "lineOne": "1 The High Street",
+    "lineTwo": "",
+    "lineThree": "",
+    "postcode": "AA1 1AA",
+    "townCity": "London",
+    "region": "Greater London"
   },
-  "entityType" : "INDIVIDUAL",
-  "employmentDetails" : {
-    "jobTitle" : "jobTitle",
-    "employmentStatus" : "EMPLOYED_FULL_TIME"
+  "accountTypes": [
+    "GOJI_INVESTMENT",
+  ],
+  "entityType": "CORPORATE",
+  "nationalities": [
+    {"nationality": "GB"},
+    {"nationality": "CH"}
+  ],
+  "dateOfBirth": "1990-01-19",
+  "migrationDetails": {
+    "existingClientId": "existingClientId",
+    "diligenceMigrationOption": "FULL_CHECK",
+    "previousCheckDate": "2000-01-23"
   },
-  "dateOfBirth" : "2000-01-23",
-  "title" : "MISS",
-  "contactDetails" : {
-    "emailAddress" : "emailAddress",
-    "telephoneNumber" : "telephoneNumber"
-  },
-  "firstName" : "firstName",
-  "nationalInsuranceNumber" : "nationalInsuranceNumber",
-  "accountTypes" : "GOJI_INVESTMENT",
-  "investmentDeclarationType" : "RESTRICTED"
+  "investorDeclarationType": "HIGH_NET_WORTH",
+  "contactDetails": {
+    "emailAddress": "example@example.com",
+    "telephoneNumber": "07123456789"
+  }
 }
 ```
 ### Description
 Migrates an existing investor onto the Goji system.
+
+<aside class="notice">
+The required <code>migrationDetails</code> allows the platform to provide an existing investor client ID where applicable and provide the diligence status as agreed with Goji before migration takes place. 
+</aside>
+
 ### Request
 | Name                                | Type   | Description                                                                                                                                                                                                           | Required |
 | ----------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |

--- a/source/includes/_investors.md
+++ b/source/includes/_investors.md
@@ -2155,7 +2155,7 @@ Content-Type: application/json
 Migrates an existing investor onto the Goji system.
 
 <aside class="notice">
-The required <code>migrationDetails</code> allows the platform to provide an existing investor client ID where applicable and provide the diligence status as agreed with Goji before migration takes place. 
+The required <code>migrationDetails</code> allows the platform to provide an existing investor ID where applicable and provide the diligence status as agreed with Goji before migration takes place. 
 </aside>
 
 ### Request

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -23,7 +23,7 @@ The encrypted string is then UTF-8 URL encoded.
 ### Verifying the signature
 
 <aside class="notice">
-You should verify that the `Authorization` header matches the expected signature string using the secret that was shared with you during onboarding.
+You should verify that the <code>Authorization</code> header matches the expected signature string using the secret that was shared with you during onboarding.
 </aside>
 
 ## `POST /webhooks`
@@ -156,11 +156,11 @@ This is fired whenever an investor's KYC status changes eg from `REFERRED` to `V
 This is fired whenever investor funds are cleared into their account eg for a bank transfer.
 
 <aside class="notice">
-If using the batch payments api this event will not trigger but instead a `BATCH_UPDATE` event will be generated once all payments have been received.
+If using the batch payments api this event will not trigger but instead a <code>BATCH_UPDATE</code> event will be generated once all payments have been received.
 </aside>
 
 <aside class="notice">
-If redirected = true, the accountType will reflect which account the money has been credited to. The intendedAccountType will
+If <code>redirected = true</code>, the <code>accountType</code> will reflect which account the money has been credited to. The <code>intendedAccountType</code> will
 contain details of where the investor wished to deposit. This scenario is most likely when depositing into an ISA and the ISA subscription
 status is preventing deposits.
 </aside>


### PR DESCRIPTION
Added two valid examples to `POST /migrate`, one for `INDIVIDUAL` and one for `CORPORATE`.
Existing example was terrible and confusing.

BEFORE:

![Screenshot 2020-06-16 at 20 03 05](https://user-images.githubusercontent.com/3105832/84817220-7c50fd00-b00c-11ea-983e-9b2b76c99319.png)


AFTER:

![image](https://user-images.githubusercontent.com/3105832/84894090-2d50a980-b098-11ea-98d3-a557ce1c9fb9.png)

