### PR TITLE
Use statuspage embedded widget on docs to highlight incidents or maintenance

### DIFF
--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -1,4 +1,5 @@
 //= require ./lib/_energize
+//= require ./lib/_statuspage
 //= require ./app/_toc
 //= require ./app/_lang
 

--- a/source/javascripts/lib/_statuspage.js
+++ b/source/javascripts/lib/_statuspage.js
@@ -1,0 +1,56 @@
+/**
+ * Statuspage.io Incident and Maintenance widget
+ * https://manage.statuspage.io/pages/9zq9y4ymrb7g/status-embed
+ */
+document.addEventListener('DOMContentLoaded', function(){
+
+  var frame = document.createElement('iframe');
+  frame.src = 'https://9zq9y4ymrb7g.statuspage.io/embed/frame';
+  frame.style.position = 'fixed';
+  frame.style.border = 'none';
+  frame.style.boxShadow = '0 20px 32px -8px rgba(9,20,66,0.25)';
+  frame.style.zIndex = '9999';
+  frame.style.transition = 'left 1s ease, bottom 1s ease, right 1s ease';
+
+  var mobile;
+  if (mobile = screen.width < 450) {
+    frame.src += '?mobile=true';
+    frame.style.height = '20vh';
+    frame.style.width = '100vw';
+    frame.style.left = '-9999px';
+    frame.style.bottom = '-9999px';
+    frame.style.transition = 'bottom 1s ease';
+  } else {
+    frame.style.height = '115px';
+    frame.style.width = '320px';
+    frame.style.left = '-9999px';
+    frame.style.right = 'auto';
+    frame.style.bottom = '60px';
+  }
+
+  document.body.appendChild(frame);
+
+  var actions = {
+    showFrame: function() {
+      if (mobile) {
+        frame.style.left = '0';
+        frame.style.bottom = '0';
+      }
+      else {
+        frame.style.left = '60px';
+        frame.style.right = 'auto'
+      }
+    },
+    dismissFrame: function(){
+      frame.style.left = '-9999px';
+    }
+  }
+
+  window.addEventListener('message', function(event){
+    if (event.data.action && actions.hasOwnProperty(event.data.action)) {
+      actions[event.data.action](event.data);
+    }
+  }, false);
+
+  window.statusEmbedTest = actions.showFrame;
+})


### PR DESCRIPTION
Include status page widget in docs for real time updates on incidents and maintenance.

Example shown below. Need to understand how far ahead of time it displays maintenance.

![Screenshot 2020-06-18 at 15 33 03](https://user-images.githubusercontent.com/368259/85033992-7b89a980-b179-11ea-9aa4-f806f98faf2d.png)
