### PR TITLE
document changes to debt settlement repayment flow

### DIFF
--- a/source/includes/debt-settlement.md.erb
+++ b/source/includes/debt-settlement.md.erb
@@ -463,6 +463,11 @@ Content-Type: application/json
 ```
 ### Description
 Generates a repayment reference to be used when depositing repayment funds.
+
+<aside class="notice">
+This legacy behaviour is only enabled for a few clients. Newly integrating clients should use <a href="#settlement-debt-post-platformapi-settlement-investor-repayment">the new behaviour</a>.
+</aside>
+
 ### Response
 | Name          | Type   | Description                                                  |
 | ------------- | ------ | ------------------------------------------------------------ |
@@ -470,7 +475,7 @@ Generates a repayment reference to be used when depositing repayment funds.
 | accountNumber | string | The account number for the repayment deposit.                |
 | sortCode      | string | The sort code for the repayment deposit.                     |
 
-## `POST /platformApi/settlement/repayment`
+## `POST /platformApi/settlement/repayment` (only valid if registering references manually)
 
 ```http
 
@@ -516,15 +521,14 @@ Content-Type: application/json
 ### Description
 Adds a repayment to an investment.
 
+<aside class="warning">
+Any users of this endpoint who are not registering a reference first will need to move to <a href="#settlement-debt-post-platformapi-settlement-investor-repayment">the new behaviour</a>.
+</aside>
+
  - The system will record the repayments and wait for a deposit into your receiving account matching the amount and reference you specified
 when making the API call.
  - Once the money is deposited the system will automatically distribute the funds to investors and notify them of a repayment.
  - The system will publish a <a href="/#webhooks-batch_update">BATCH_UPDATE</a> webhook with a type of `REPAYMENTS` to update you on the progress of the distribution.
-
-<aside class="notice">
-This behaviour is the default for newly integrating clients, if you wish to enable this feature please contact customer support. Prior to this
-the system will validate the funds are already present matching the reference and amount and will return an error otherwise.
-</aside>
 
 ### Request
 | Name                              | Type   | Description                                                                    | Required |
@@ -535,6 +539,78 @@ the system will validate the funds are already present matching the reference an
 | investorRepayments[].type         | string | The type of the repayment Possible values are: <br>`CAPITAL`<br>`INTEREST`<br> | required |
 | investorRepayments[].amount       | ref    | The amount being repaid                                                        | required |
 | investorRepayments[].tax          | ref    | The amount of tax being withheld from this repayment                           | optional |
+
+## `POST /platformApi/settlement/investor-repayment`
+
+```http
+
+POST /platformApi/settlement/investor-repayment HTTP/1.1
+Host: api-sandbox.goji.investments
+Content-Type: application/json
+Authorization: Basic ...
+
+{
+  "reference" : "reference",
+  "sourceWalletId": "sourceWalletId",
+  "investorRepayments" : [ {
+    "amount" : {
+      "amount" : 2.68,
+      "currency" : "currency"
+    },
+    "investmentId" : "investmentId",
+    "tax" : {
+      "amount" : 2.68,
+      "currency" : "currency"
+    },
+    "type" : "CAPITAL"
+  }, {
+    "amount" : {
+      "amount" : 2.68,
+      "currency" : "currency"
+    },
+    "investmentId" : "investmentId",
+    "tax" : {
+      "amount" : 2.68,
+      "currency" : "currency"
+    },
+    "type" : "CAPITAL"
+  } ]
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "repaymentBatchReference": "repaymentBatchReference"
+}
+```
+### Description
+Adds repayments to investments from a specified wallet.
+
+ - On receiving the API call, the system will reserve money in the wallet and start the distribution process provided the "sourceWalletId" has enough funds.
+ - There is no need to manually move money to the receiving account.
+ - The system will publish a <a href="/#webhooks-batch_update">BATCH_UPDATE</a> webhook with a type of `REPAYMENTS` to provide an update on the progress of the distribution.
+
+<aside class="notice">
+This endpoint is the only call required to repay investments for any platform onboarded from 1st November 2021.
+</aside>
+
+### Request
+| Name                              | Type   | Description                                                                    | Required |
+| --------------------------------- | ------ | ------------------------------------------------------------------------------ | -------- |
+| reference                         | string | The payment reference used for the repayment of funds. Will also be present on `INVESTOR_FUNDS_RECEIVED` webhook | required |
+| sourceWalletId                    | string | The wallet this distribution should be made from                               | required |
+| investorRepayments                | array  | The repayments per investor.                                                   | required |
+| investorRepayments[].investmentId | string | The ID of the of the investment                                                | required |
+| investorRepayments[].type         | string | The type of the repayment Possible values are: <br>`CAPITAL`<br>`INTEREST`<br> | required |
+| investorRepayments[].amount       | ref    | The amount being repaid                                                        | required |
+| investorRepayments[].tax          | ref    | The amount of tax being withheld from this repayment                           | optional |
+### Response
+| Name                     | Type   | Description                                  |
+| ------------------------ | ------ | -------------------------------------------- |
+| repaymentBatchReference  | string | The unique ID for this repayment request     |
 
 ## `GET /platformApi/settlement/investors/{clientId}/accounts/{accountType}/investments`
 


### PR DESCRIPTION
Document updates to settlement flow.

- add notices to `/platformApi/settlement/repayment/reference` and `/platformApi/settlement/repayment` to signal they are considered legacy.
- add new endpoint `/platformApi/settlement/investor-repayment` with required `sourceWalletId` in the body for the new flow

New endpoint docs:
![image](https://user-images.githubusercontent.com/33283647/138825271-2d3cb948-b00a-4080-a4c8-8ee313cc1395.png)

Existing endpoints:
![image](https://user-images.githubusercontent.com/33283647/138825202-7ff089db-b69f-4380-a491-e43c695e1176.png)
![image](https://user-images.githubusercontent.com/33283647/138825238-1fbec5b6-10a2-47c9-bb03-57c2db4bf9c7.png)

