### PR TITLE
GJ 2948

### DIFF
--- a/source/includes/debt-settlement.md.erb
+++ b/source/includes/debt-settlement.md.erb
@@ -385,7 +385,7 @@ Authorization: Basic ...
     },
     "bankAccountId" : "bankAccountId",
     "reference" : "reference",
-    "repaymentReference" : "repaymentReference"
+    "repaymentReference" : "repaymentReference",
     "investmentId" : "investmentId",
     "premium" : {
       "amount" : 2.68,


### PR DESCRIPTION
- Added missing `,`

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->