### PR TITLE
fix: GTS-29174 - GitHub actions deploy

### DIFF
--- a/.github/workflows/deply_docs.yml
+++ b/.github/workflows/deply_docs.yml
@@ -26,8 +26,8 @@ jobs:
     - run: bundle exec middleman build --clean
 
     - name: deploy
-      uses: peaceiris/actions-gh-pages@v2.3.1
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./build
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build
+        publish_branch: gh-pages


### PR DESCRIPTION
Fix how we deploy via GitHub Actions. It was trying to use the `ACTIONS_DEPLOY_KEY` method, which required someone to manually create their own SSH key, and add it to this repository's "Deploy keys" tab in "Settings". 

This deploy key no longer exists, so it is failing.

Moving the method over to use the default built-in `GITHUB_TOKEN` so that it does not depend on a particular user maintaining a key/token.